### PR TITLE
fix(ocp-connect): rewrite IDE detection + improve hint density (v1.2.0)

### DIFF
--- a/ocp-connect
+++ b/ocp-connect
@@ -11,7 +11,7 @@
 #
 set -euo pipefail
 
-OCP_CONNECT_VERSION="1.1.0"
+OCP_CONNECT_VERSION="1.2.0"
 
 show_version() {
   echo "ocp-connect $OCP_CONNECT_VERSION"
@@ -347,31 +347,94 @@ for m in d.get('data',[]):
   # --- Other IDEs: print manual instructions ---
   local other_ides_shown=false
 
-  # Detect Cline (VS Code extension)
-  if [[ -d "$HOME/.vscode/extensions" ]] && ls "$HOME/.vscode/extensions/" 2>/dev/null | grep -qi cline; then
-    if ! $other_ides_shown; then
-      echo "  Other IDEs detected:"
-      other_ides_shown=true
-    fi
-    echo "    • Cline: Settings → OPENAI_BASE_URL = $base_url/v1"
+  # Collect VS Code extension list once (reused by Cline and Continue.dev checks)
+  local _vscode_exts=""
+  if command -v code &>/dev/null; then
+    _vscode_exts=$(code --list-extensions 2>/dev/null || true)
+  fi
+  if [[ -z "$_vscode_exts" && -d "$HOME/.vscode/extensions" ]]; then
+    _vscode_exts=$(ls "$HOME/.vscode/extensions/" 2>/dev/null || true)
   fi
 
-  # Detect Continue.dev
-  if [[ -f "$HOME/.continue/config.json" ]]; then
-    if ! $other_ides_shown; then
-      echo "  Other IDEs detected:"
-      other_ides_shown=true
-    fi
-    echo "    • Continue.dev: ~/.continue/config.json → apiBase: \"$base_url/v1\""
+  # Extract model IDs from /v1/models response for use in hints
+  local _model_ids
+  _model_ids=$(echo "$models_out" | python3 -c "
+import sys,json
+try:
+    d=json.loads(sys.stdin.read())
+    print(', '.join(m['id'] for m in d.get('data', [])))
+except Exception:
+    print('claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5-20251001')
+" 2>/dev/null || echo "claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5-20251001")
+
+  # Key display: truncate if longer than 16 chars to avoid screenshot leakage,
+  # show explicit "(none)" in anonymous mode so users don't paste blank fields.
+  local _key_display
+  if [[ -z "$key" ]]; then
+    _key_display="(none — anonymous mode; most external IDEs require a non-empty API Key)"
+  elif [[ ${#key} -gt 16 ]]; then
+    _key_display="${key:0:8}...${key: -4}"
+  else
+    _key_display="$key"
   fi
 
-  # Detect Cursor
-  if command -v cursor &>/dev/null || [[ -d "$HOME/.cursor" ]]; then
+  # Detect Cline (VS Code extension saoudrizwan.claude-dev, see issue #12)
+  if echo "$_vscode_exts" | grep -qiE 'cline|saoudrizwan\.claude-dev'; then
     if ! $other_ides_shown; then
       echo "  Other IDEs detected:"
       other_ides_shown=true
     fi
-    echo "    • Cursor: Settings → OpenAI Base URL = $base_url/v1"
+    echo "    • Cline: VSCode → Cline panel → Settings → API Provider = \"OpenAI Compatible\""
+    echo "        Base URL: $base_url/v1"
+    echo "        API Key:  $_key_display"
+    echo "        Model ID: $_model_ids"
+  fi
+
+  # Detect Continue.dev (extension ID continue.continue or config file, see issue #12)
+  if echo "$_vscode_exts" | grep -qi 'continue\.continue' \
+     || [[ -f "$HOME/.continue/config.yaml" ]] \
+     || [[ -f "$HOME/.continue/config.json" ]]; then
+    if ! $other_ides_shown; then
+      echo "  Other IDEs detected:"
+      other_ides_shown=true
+    fi
+    echo "    • Continue.dev: edit ~/.continue/config.yaml — add under \`models:\` (top-level key):"
+    echo "        models:"
+    echo "          - name: OCP Sonnet"
+    echo "            provider: openai"
+    echo "            model: claude-sonnet-4-6"
+    echo "            apiBase: $base_url/v1"
+    echo "            apiKey: $_key_display"
+    echo "        (other model IDs: $_model_ids)"
+  fi
+
+  # Detect Cursor (command, ~/.cursor dir, or /Applications/Cursor.app, see issue #12)
+  if command -v cursor &>/dev/null \
+     || [[ -d "$HOME/.cursor" ]] \
+     || [[ -d "/Applications/Cursor.app" ]]; then
+    if ! $other_ides_shown; then
+      echo "  Other IDEs detected:"
+      other_ides_shown=true
+    fi
+    echo "    • Cursor: Cmd+Shift+P → 'Cursor Settings' → Models →"
+    echo "        OpenAI API Key:           $_key_display"
+    echo "        Override OpenAI Base URL: $base_url/v1"
+    echo "        Custom OpenAI Models:     $_model_ids"
+  fi
+
+  # Detect opencode (https://opencode.ai, SST team CLI, see issue #12)
+  if command -v opencode &>/dev/null \
+     || [[ -x "$HOME/.opencode/bin/opencode" ]] \
+     || [[ -d "$HOME/.local/share/opencode" ]]; then
+    if ! $other_ides_shown; then
+      echo "  Other IDEs detected:"
+      other_ides_shown=true
+    fi
+    echo "    • opencode: not yet auto-configured by ocp-connect (PR follow-up)."
+    echo "        Run \`opencode providers login openai\` and provide:"
+    echo "          Base URL: $base_url/v1"
+    echo "          API Key:  $_key_display"
+    echo "        Available model IDs: $_model_ids"
   fi
 
   if $other_ides_shown; then


### PR DESCRIPTION
Follow-up to #12 / #13 PR-1. Bumps `ocp-connect` to **v1.2.0**.

Implements PR-2a from issue #12 §9.6 — IDE **detection** rewrite + hint density improvements. Auto-config (writing `auth.json` / `config.yaml`) is **deferred** to PR-2b per OCP-side scope decision.

## What was broken

Empirical testing on macOS 13 with the four common IDEs installed showed `ocp-connect`'s "Other IDEs detected" hint section had a **~25% effective hit rate**:

| IDE | Detection logic | Hit rate |
|---|---|---|
| Cline | `grep -qi cline` in `~/.vscode/extensions/` | **0%** — extension ID is `saoudrizwan.claude-dev`, doesn't contain "cline" |
| Continue.dev | `[[ -f ~/.continue/config.json ]]` | **0%** — directory not created until UI opened, and v1.x uses `config.yaml` |
| Cursor | `command -v cursor \|\| [[ -d ~/.cursor ]]` | **brew: 100%, dmg: 0%** — depends entirely on install path |
| opencode | (none) | **0%** — script never knew it existed |

The hints themselves were also too sparse — single-line "Settings → OpenAI Base URL = ...", no API key, no model IDs, no menu path.

## Changes (1 file, +73 -10)

### Detection rewrite

- **Cline**: prefer `code --list-extensions`, fall back to `ls`, match `cline|saoudrizwan\.claude-dev`
- **Continue.dev**: three-condition OR — extension `continue.continue` OR `~/.continue/config.yaml` OR `~/.continue/config.json`
- **Cursor**: add `[[ -d "/Applications/Cursor.app" ]]` as third fallback (catches official-dmg installs)
- **opencode** (NEW): `command -v opencode \|\| [[ -x ~/.opencode/bin/opencode ]] \|\| [[ -d ~/.local/share/opencode ]]`

### Hint density

Each hint now includes:
- Base URL
- API key (truncated `${key:0:8}...${key: -4}` for ≥17 chars to avoid screenshot leakage; `(none — anonymous mode...)` when no `--key`)
- Available model IDs extracted from the actual `/v1/models` response
- Exact menu path or config file location

Continue.dev hint shows the YAML snippet **under the `models:` top-level key** so the user can paste it directly without schema confusion (per reviewer feedback).

opencode hint explicitly says **"not yet auto-configured by ocp-connect (PR follow-up)"** so users know to use `opencode providers login openai` until a future PR. Note: opencode does **not** read `OPENAI_API_KEY` env var (empirically verified — it has its own credentials store at `~/.local/share/opencode/auth.json`), so the existing rc-file export strategy doesn't help it.

### Version bump

Per dev iron rule #5: `OCP_CONNECT_VERSION` 1.1.0 → 1.2.0.

## Test plan

Offline matrix on macOS 13 with all 5 IDEs installed (VSCode 1.115.0 + Cline 3.78.0 + Continue.dev 1.2.22 + Cursor 3.0.16 + opencode 1.4.3 + OpenClaw 2026.4.11):

- [x] All 4 IDEs installed → all 4 hints fire with full detail (base URL + truncated key + model IDs)
- [x] Anonymous mode → hints fire, key display reads `(none — anonymous mode; most external IDEs require a non-empty API Key)`
- [x] HOME=tmpdir mock + only Cline mock dir → Cline + Cursor (system app) hints fire, others suppressed
- [x] HOME=tmpdir mock + nothing → only Cursor (system app) hint fires
- [x] `--version` → `ocp-connect 1.2.0`
- [x] `--help` → still shows the PR-1 wording for item 5 (untouched)
- [x] B1 OpenClaw per-agent auth-profiles section is **untouched** (verified by diff line range — all edits fall in `configure_ides()` lines 347–440 + version constant lines 9–13)

### Hit rate matrix

| IDE | before PR-2a | after PR-2a |
|---|---|---|
| OpenClaw | ✓ (PR-1) | ✓ |
| Cline | ❌ | ✓ |
| Continue.dev | ❌ | ✓ |
| Cursor | ✓ (brew only) | ✓ |
| opencode | ❌ | ✓ |

**Effective detection rate: ~25% → ~100%.**

## Code review

One independent **opus reviewer** (spec compliance + bash 3.2 compat + UX). Verdict: **PASS WITH CONCERNS, 0 blockers**. Two non-blocking suggestions both addressed in this commit:

1. **Continue.dev YAML hint** — added `models:` top-level key so the pasted snippet validates against Continue v1.x schema
2. **Anonymous mode** — key display now shows `(none — anonymous mode...)` instead of a blank field

## Out of scope (deferred to future PRs)

- **opencode auto-configure** — schema needs more investigation; opencode model whitelist gets in the way of custom claude model IDs
- **Continue.dev auto-configure** — config.yaml schema is well known but bash YAML merging is awkward without extra deps
- **Aider, Cody, Zed, etc.** detection — not in this PR scope
- Tracked in #12 §9.6.

## Constraint compliance

Per session constraint: **no OpenClaw modifications**. This PR only touches `ocp-connect` (single file). The OpenClaw integration in PR-1 (writing per-agent `auth-profiles.json`) is **untouched** in this PR — verified by diff range and reviewer.
