### PR TITLE
feat(server): anonymous key allowlist for multi-mode (v3.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,23 @@ ocp keys revoke son-ipad   # Revoke a key
 | `shared` | `CLAUDE_AUTH_MODE=shared` + `PROXY_API_KEY=xxx` | Everyone shares one key |
 | `multi` | `CLAUDE_AUTH_MODE=multi` + `OCP_ADMIN_KEY=xxx` | Per-person keys with usage tracking (recommended) |
 
+### Anonymous Access (optional)
+
+In `multi` mode, the admin can designate a single well-known "anonymous" key that bypasses `validateKey()` and grants public read/write access. This is useful for letting LAN users (or clients like OpenClaw multi-agent setups) connect without individual per-user keys.
+
+**Enable**:
+
+```bash
+export PROXY_ANONYMOUS_KEY=ocp_public_anon   # or any string of your choice
+ocp start                                    # or however you start the server
+```
+
+**Client side**: the anonymous key value is exposed via `GET /health` as the field `anonymousKey` (null when not set). Clients like `ocp-connect` can auto-discover and use it, so the end user doesn't need to get a personal key from the admin.
+
+**Security note**: setting this env var is an **opt-in** to public access — anyone who can reach your OCP endpoint can use it, up to any rate limits you configure. Don't enable this on internet-exposed OCP instances without additional protection.
+
+**Not a secret**: because `/health` is an unauthenticated endpoint, the anonymous key is **publicly readable** by anyone who can reach the server. That is intentional — the key exists so clients can self-configure without out-of-band coordination. Treat it as a convenience handle, not as an access credential.
+
 ### Important Notes
 
 - All users share your Claude Pro/Max **rate limits** (5h session + 7d weekly)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-claude-proxy",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {

--- a/server.mjs
+++ b/server.mjs
@@ -97,6 +97,10 @@ const BIND_ADDRESS = process.env.CLAUDE_BIND || "127.0.0.1";
 const NO_CONTEXT = process.env.CLAUDE_NO_CONTEXT === "true";
 const AUTH_MODE = process.env.CLAUDE_AUTH_MODE || (PROXY_API_KEY ? "shared" : "none");
 const ADMIN_KEY = process.env.OCP_ADMIN_KEY || "";
+const PROXY_ANONYMOUS_KEY = process.env.PROXY_ANONYMOUS_KEY || "";
+if (PROXY_ANONYMOUS_KEY && AUTH_MODE !== "multi") {
+  console.warn("WARNING: PROXY_ANONYMOUS_KEY is set but AUTH_MODE is not 'multi' — anonymous key will be ignored");
+}
 
 if (AUTH_MODE === "shared" && !PROXY_API_KEY) {
   console.warn("WARNING: AUTH_MODE=shared but PROXY_API_KEY is not set — all requests will pass unauthenticated");
@@ -1120,7 +1124,15 @@ const server = createServer(async (req, res) => {
             authKeyName = "admin";
           }
         }
-        if (authKeyName !== "admin") {
+        if (authKeyName !== "admin" && PROXY_ANONYMOUS_KEY) {
+          // anonymous allowlist (issue #12 §14 Path A) — same check as multi branch
+          const anonBuf = Buffer.from(PROXY_ANONYMOUS_KEY);
+          const tokenBufA = Buffer.from(token);
+          if (anonBuf.length === tokenBufA.length && timingSafeEqual(anonBuf, tokenBufA)) {
+            authKeyName = "anonymous";
+          }
+        }
+        if (authKeyName !== "admin" && authKeyName !== "anonymous") {
           const keyInfo = validateKey(token);
           if (keyInfo) { authKeyName = keyInfo.name; authKeyId = keyInfo.id; }
         }
@@ -1146,7 +1158,17 @@ const server = createServer(async (req, res) => {
             isAdminToken = true;
           }
         }
-        if (!isAdminToken) {
+        // === NEW: anonymous allowlist (issue #12 §14 Path A) ===
+        let isAnonymousToken = false;
+        if (!isAdminToken && PROXY_ANONYMOUS_KEY) {
+          const anonBuf = Buffer.from(PROXY_ANONYMOUS_KEY);
+          const tokenBuf3 = Buffer.from(token);
+          if (anonBuf.length === tokenBuf3.length && timingSafeEqual(anonBuf, tokenBuf3)) {
+            authKeyName = "anonymous";
+            isAnonymousToken = true;
+          }
+        }
+        if (!isAdminToken && !isAnonymousToken) {
           const keyInfo = validateKey(token);
           if (!keyInfo) {
             return jsonResponse(res, 401, { error: { message: "Unauthorized: invalid or revoked API key", type: "auth_error" } });
@@ -1204,6 +1226,7 @@ const server = createServer(async (req, res) => {
       claudeBinary: CLAUDE,
       claudeBinaryOk: binaryOk,
       authMode: AUTH_MODE,
+      anonymousKey: PROXY_ANONYMOUS_KEY || null,
       auth: authStatus,
       config: {
         timeout: TIMEOUT,


### PR DESCRIPTION
Implements issue #12 §14 **Path A**. Bumps OCP to **v3.7.0**.

## What this does

Lets the OCP admin designate a single well-known **"anonymous" key** that bypasses `validateKey()` while keeping `AUTH_MODE=multi`. The key is **opt-in via `PROXY_ANONYMOUS_KEY` env var** and exposed via `/health` for client self-discovery.

### The problem

After PR-1 (#13), we know OpenClaw multi-agent setups **require** a per-agent `auth-profiles.json` with a **non-empty** `key` field. OCP multi-mode rejects any non-empty Bearer token that isn't in the keys database (`server.mjs:1152`), creating a deadlock: the only way for OpenClaw to use OCP is with a real admin-issued key — which kills the "anonymous LAN proxy" UX promise.

### The fix

Path A introduces a **server-side allowlist** for a single admin-chosen anonymous key. OpenClaw writes this key into its agent profiles just like a real key; OCP short-circuits `validateKey()` when the key matches. No per-user coordination needed, admin still controls the policy (can rotate, can unset, can rate-limit).

## Changes (3 files, +43 -3)

### `server.mjs` (+27 -2)

- **L100-103** — `PROXY_ANONYMOUS_KEY` constant + warning if set without `AUTH_MODE=multi`
- **L1127-1138** (localhost branch) — anonymous allowlist check so localhost clients using the key are labeled `"anonymous"` instead of `"local"` in stats (reviewer feedback)
- **L1153-1163** (multi branch) — anonymous allowlist check between ADMIN check and `validateKey`; uses `timingSafeEqual` with explicit length guard (consistent with the admin/shared key patterns)
- **L1221** — `/health` response includes `anonymousKey` field (null when unset, the actual value when set)

### `package.json` (+1 -1)

`3.6.0` → `3.7.0`.

### `README.md` (+17)

New **"Anonymous Access (optional)"** subsection under Auth Modes:
- Enable example (`export PROXY_ANONYMOUS_KEY=...`)
- Client-side `/health` discovery explanation
- **Security note**: opt-in, rate-limit warning
- **"Not a secret" note**: `/health` is unauthenticated by design, so the anon key is publicly readable — it's a convenience handle, not a credential

## Test plan

Offline tests on macOS 13 — local server bound to `0.0.0.0:8889`, `CLAUDE_AUTH_MODE=multi`, `PROXY_ANONYMOUS_KEY=ocp_public_anon_TEST`, `CLAUDE=/bin/echo` mock:

| # | Request | Expected | Actual | ✓ |
|---|---|---|---|---|
| 1 | `GET /health` | `anonymousKey: "ocp_public_anon_TEST"` in JSON | matched | ✓ |
| 2 | `POST /v1/chat/completions` from `172.16.2.29` with `Bearer ocp_WRONG_KEY` | HTTP 401 fast | 401 in 15ms, `"invalid or revoked API key"` | ✓ |
| 3 | Same with `Bearer ocp_public_anon_TEST` | auth passes (then mock claude hangs) | 3s timeout after auth, no 401 | ✓ |
| 4 | Same with NO `Authorization` header | pre-existing empty-anonymous path still works | 3s timeout after auth, no 401 | ✓ |

`node --check server.mjs` passes. Syntax OK.

## Code review

**One independent opus reviewer** — PASS WITH CONCERNS, **0 blockers**. Two strong-recommend items addressed in this commit:

1. **Localhost branch was missed in the first draft** — reviewer pointed out a localhost client using the anon key would be labeled `"local"` not `"anonymous"` in stats. Fixed by applying the same allowlist check in the localhost branch.
2. **README security note** — added explicit "not a secret" framing so users don't mistakenly treat the anon key as a credential.

Reviewer nits (`tokenBuf3` naming, stats subcategory for header-less vs anon-key anonymous) are deferred — they don't affect correctness and can be a follow-up.

## Constraint compliance

Per session constraint: **no OpenClaw modifications**. This PR only touches OCP server code (`server.mjs`), its package manifest, and its README. OpenClaw is not in this repo. ✓

## Follow-up (not in this PR)

After merge + OCP instance at `172.16.2.30` is restarted with `PROXY_ANONYMOUS_KEY` set, a tiny ocp-connect follow-up can add auto-discovery:

1. On startup, `ocp-connect` calls `GET /health`
2. If `anonymousKey` is non-null and `--key` was not provided, auto-use it
3. User gets zero-config OCP ↔ OpenClaw connectivity, no admin coordination, no `--key` flag

That's tracked in #12 §14 but intentionally **not in this PR** (server-only scope).

## Deployment checklist (for you to do after merge)

- [ ] SSH to the machine running OCP at `172.16.2.30`
- [ ] Add `PROXY_ANONYMOUS_KEY=<your chosen string>` to the OCP startup environment (systemd unit / shell rc / launchd plist, wherever it lives)
- [ ] Restart OCP
- [ ] `curl http://172.16.2.30:3456/health | jq .anonymousKey` — confirm the field is populated
- [ ] (Optional) tell ocp-connect users they can now omit `--key` once the ocp-connect follow-up PR lands
