### PR TITLE
feat(ocp-connect): auto-discover anonymous key from /health (v1.3.0)

### DIFF
--- a/ocp-connect
+++ b/ocp-connect
@@ -11,7 +11,7 @@
 #
 set -euo pipefail
 
-OCP_CONNECT_VERSION="1.2.0"
+OCP_CONNECT_VERSION="1.3.0"
 
 show_version() {
   echo "ocp-connect $OCP_CONNECT_VERSION"
@@ -449,7 +449,9 @@ main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --port)  port="${2:?'--port requires a value'}"; shift 2 ;;
-      --key)   key="${2:?'--key requires a value'}"; shift 2 ;;
+      --key)   key="${2:?'--key requires a value'}"
+               [[ -z "$key" ]] && { echo "Error: --key cannot be empty (omit --key entirely for anonymous mode)"; exit 1; }
+               shift 2 ;;
       --version) show_version; exit 0 ;;
       --help|-h) show_help; exit 0 ;;
       -*)      echo "Unknown option: $1"; show_help; exit 1 ;;
@@ -502,6 +504,33 @@ main() {
 
   echo "  Remote OCP v$remote_version  (auth: $auth_mode)"
   echo ""
+
+  # Step 2.5: auto-discover anonymous key from /health (issue #12 §14 Path A).
+  # When the OCP admin set PROXY_ANONYMOUS_KEY, the server advertises it via
+  # /health.anonymousKey. If the user didn't pass --key, use it automatically so
+  # `ocp-connect <host>` works zero-config for OpenClaw multi-agent setups.
+  if [[ -z "$key" ]]; then
+    local anon_key
+    anon_key=$(echo "$health_json" | python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    k = d.get('anonymousKey')
+except Exception:
+    k = None
+print(k if k else '')
+" 2>/dev/null || echo "")
+    if [[ -n "$anon_key" ]]; then
+      key="$anon_key"
+      local _anon_display="$anon_key"
+      if [[ ${#anon_key} -gt 16 ]]; then
+        _anon_display="${anon_key:0:8}...${anon_key: -4}"
+      fi
+      echo "  ⓘ Using server-advertised anonymous key: $_anon_display"
+      echo "    (set by admin via PROXY_ANONYMOUS_KEY; see issue #12 §14 Path A)"
+      echo ""
+    fi
+  fi
 
   # Step 3: Determine if key is needed
   if [[ "$auth_mode" != "none" && -z "$key" ]]; then


### PR DESCRIPTION
Closes the zero-config loop opened by #15. Bumps ocp-connect to **v1.3.0**.

## Summary

After #15 (server v3.7.0), the OCP server exposes the admin-chosen anonymous key via `GET /health.anonymousKey`. Before this PR, users still had to copy that key and pass it as `--key` every time. This commit makes `ocp-connect <host>` read the key from `/health` and use it automatically when `--key` is absent.

**Result**: `ocp-connect 172.16.2.30` (zero args, fresh machine) now correctly configures OpenClaw multi-agent against a v3.7.0 OCP instance that has `PROXY_ANONYMOUS_KEY` set. **No admin coordination, no per-user keys, no manual flags.**

This is the last mile of issue #12 §14 Path A.

## Changes (1 file, +31 -2)

### `ocp-connect`

- **Version bump** `1.2.0` → `1.3.0`
- **New Step 2.5** between existing Step 2 (Show remote info) and Step 3 (Determine if key is needed):
  - Short-circuits if `--key` was passed explicitly (user intent wins)
  - Parses `health_json.anonymousKey` via python3 with try/except
  - If the server advertised a non-empty anon key → assigns it to internal `key` variable, prints info banner with truncated value + `#12 §14 Path A` reference
- **Defensive `--key ""` rejection** in arg parser — bash `${2:?}` already catches this, but added an explicit check for cleaner error message (`"omit --key entirely for anonymous mode"`)

All downstream code (key verification, rc file exports, launchctl, OpenClaw agentDir seeding, smoke test, IDE hints) is **unchanged** — it reads the same `key` variable transparently.

## Backward compatibility

- **Old OCP servers (<3.7.0)** that don't return `anonymousKey` in `/health`: `d.get('anonymousKey')` → `None` → empty string → `[[ -n "" ]]` false → fall-through to existing Step 3 path. **Behavior 100% identical to v1.2.0**.
- **New OCP servers that haven't set `PROXY_ANONYMOUS_KEY`**: field is null, same fall-through.

No user-visible regression. No new CLI flag. No new prompt.

## Test plan — live 172.16.2.30 (v3.7.0, `PROXY_ANONYMOUS_KEY=ocp_public_anon_v1`)

### T1: cold install + zero args

```
$ ~/projects/ocp/ocp-connect 172.16.2.30
OCP Connect v1.3.0
Remote OCP v3.7.0  (auth: multi)
  ⓘ Using server-advertised anonymous key: ocp_publ...n_v1
    (set by admin via PROXY_ANONYMOUS_KEY; see issue #12 §14 Path A)
  ✓ API accessible (3 models available)
    ✓ Per-agent auth profile seeded (2):
      • /Users/taodeng/.openclaw/agents/main/agent/auth-profiles.json
      • /Users/taodeng/.openclaw/agents/macbook_bot/agent/auth-profiles.json
  ✓ Smoke test passed: OK
EXIT 0
```

Verified profile content:
```
macbook_bot: key = ocp_public_anon_v1
main:        key = ocp_public_anon_v1
```

- [x] `ⓘ Using server-advertised anonymous key` banner printed
- [x] Smoke test passed without prompting for a key
- [x] Both agentDir `auth-profiles.json` files seeded with the anon key
- [x] `.bashrc` exports `OPENAI_API_KEY=ocp_public_anon_v1`
- [x] `launchctl setenv` propagates anon key system-wide

### T2: `--key` explicit still wins

`ocp-connect 172.16.2.30 --key ocp_<real_key>` — auto-discovery banner **NOT** shown, explicit key used throughout.

### T3: `--key ""` rejected

`ocp-connect 172.16.2.30 --key ""` — exits with clear error.

### T4: `--version`

`ocp-connect --version` → `ocp-connect 1.3.0`.

### Pending: Telegram end-to-end (after merge)

Restart gateway + send a Telegram message to `@deng_macbook_bot`. Expected: bot replies via `ocp/claude-sonnet-4-6`, `auth-state.json errorCount=0, lastUsed` updated, no `No API key found` events.

## Code review

One independent **opus reviewer**. Verdict: **PASS WITH CONCERNS, 0 blockers**. 

Reviewer's Concern B (`--key ""` edge case) turned out to be a **false alarm on my verification**: bash `${2:?}` expansion already rejects empty strings (tested). Added an extra defensive check anyway for cleaner error message and to protect against future arg-parser refactors. Reviewer's other nits (cosmetic simplifications) are deferred.

## Constraint compliance

- No OpenClaw modifications ✓
- Only `ocp-connect` touched in this PR ✓
- Completely backward-compatible with v1.2.0 user base ✓
- Additive change, zero removed features ✓

## The 4-PR story this completes

| PR | Title | Layer |
|---|---|---|
| #13 (v1.1.0 ocp-connect) | per-agent auth-profiles + UX fixes | client |
| #14 (v1.2.0 ocp-connect) | IDE detection rewrite + hint density | client |
| #15 (v3.7.0 server) | anonymous key allowlist (Path A) | server |
| **#16 (v1.3.0 ocp-connect)** | **auto-discover anonymous key from /health** | **client** |

With all four merged and OCP server restarted with `PROXY_ANONYMOUS_KEY` set, `ocp-connect <host>` becomes a true zero-config command.
