### PR TITLE
[Cleanup] Remove stale-cache compensation for hallucinated endpoint

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -930,9 +930,6 @@ async function handleUsage(_req, res) {
     data = await fetchUsageFromApi();
     if (!data.error) {
       usageCache = { data, fetchedAt: now };
-    } else if (usageCache.data) {
-      // Fallback to stale cache on error (e.g. 429 rate limit)
-      data = { ...usageCache.data, _stale: true, _fetchError: data.error };
     }
   }
   // Always attach live model stats and proxy stats (not cached)
@@ -1004,8 +1001,6 @@ async function handleStatus(_req, res) {
     usage = await fetchUsageFromApi();
     if (!usage.error) {
       usageCache = { data: usage, fetchedAt: now };
-    } else if (usageCache.data) {
-      usage = { ...usageCache.data, _stale: true };
     }
   }
 


### PR DESCRIPTION
## Summary

Cleanup of drift debt left by cb6c2a8 (2026-04-12). That commit extended USAGE_CACHE_TTL from 5min to 15min and added stale-cache fallback branches in handleUsage/handleStatus to mask the fact that b87992f's hallucinated /api/oauth/usage endpoint started 429-ing within 24h of deployment.

Now that PR #21 restores the correct header-based endpoint from /v1/messages, this compensation is dead code hiding a problem that no longer exists.

## Blocked by

**#21** (PR B: Restore header-based /usage). Merge that first.

This PR is based on the PR B branch, not main, to keep the diff focused.

## Changes

- `handleUsage()`: remove `else if (usageCache.data)` stale fallback branch (3 lines)
- `handleStatus()`: remove `else if (usageCache.data)` stale fallback branch (2 lines)
- `USAGE_CACHE_TTL`: already reset to `5 * 60 * 1000` (5min) in PR B's rewritten block — no change needed here.

Total: **5 deletions**, 0 additions.

## Why not `git revert cb6c2a8`?

The file structure around the compensation differs significantly after PR B's rewrite of the whole Plan-usage-probe block, so a clean revert would conflict. Manually deleting the two branches and relying on PR B's TTL reset is cleaner.

## Test plan

- [x] `node -c server.mjs` syntax check
- [ ] Reviewer: confirm no `_stale` / `_fetchError` references remain anywhere
- [ ] Reviewer: confirm dashboard handles a plain `{error}` response gracefully (same behaviour as pre-cb6c2a8)