### PR TITLE
[Cleanup] Remove stale-cache compensation for hallucinated endpoint

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -930,9 +930,6 @@ async function handleUsage(_req, res) {
     data = await fetchUsageFromApi();
     if (!data.error) {
       usageCache = { data, fetchedAt: now };
-    } else if (usageCache.data) {
-      // Fallback to stale cache on error (e.g. 429 rate limit)
-      data = { ...usageCache.data, _stale: true, _fetchError: data.error };
     }
   }
   // Always attach live model stats and proxy stats (not cached)
@@ -1004,8 +1001,6 @@ async function handleStatus(_req, res) {
     usage = await fetchUsageFromApi();
     if (!usage.error) {
       usageCache = { data: usage, fetchedAt: now };
-    } else if (usageCache.data) {
-      usage = { ...usageCache.data, _stale: true };
     }
   }
 


### PR DESCRIPTION
Replaces #22 (auto-closed when base branch fix/usage-endpoint-alignment was deleted after PR #21 merge).

## Summary
Removes the stale-cache fallback compensation that `cb6c2a8` added to mask the unstable hallucinated `/api/oauth/usage` endpoint. With PR #21 restoring the header-based approach, this compensation is dead code.

## Changes
- `handleUsage`: drop stale-cache fallback branch (3 lines)
- `handleStatus`: drop stale-cache fallback branch (2 lines)
- `USAGE_CACHE_TTL = 5 * 60 * 1000` already reset in PR #21

## Claude Code Alignment Evidence
- cli.js vE4 (line 1662) does not rely on any stale-cache layer; header extraction is per-request.
- See ALIGNMENT.md Historical Lesson for context.

Depends on: already-merged #21 (fd7973a) and #20 (2853088).