### PR TITLE
[Hotfix] Use OAuth Bearer + anthropic-beta header for usage probe

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -810,8 +810,9 @@ async function fetchUsageFromApi() {
   const doFetch = (bearerToken) => fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",
     headers: {
-      "x-api-key": bearerToken,
+      "Authorization": `Bearer ${bearerToken}`,
       "anthropic-version": "2023-06-01",
+      "anthropic-beta": "oauth-2025-04-20",
       "Content-Type": "application/json",
     },
     body,


### PR DESCRIPTION
## Summary
Follow-up to #21. OCP uses OAuth tokens (Claude Pro/Max) but the restored `fetchUsageFromApi()` copied golden v3.0.0 verbatim, which used `x-api-key`. With an OAuth token, `x-api-key` returns 401 and breaks `/usage`.

## Claude Code Alignment Evidence
- cli.js constant: `qJ="oauth-2025-04-20"`
- cli.js pattern for OAuth calls: `{Authorization:\`Bearer \${K.accessToken}\`,"anthropic-beta":qJ}`
- Multiple call sites confirmed (e.g. /v1/files, /v1/sessions)

## Test Plan
- [x] node -c server.mjs passes
- [ ] After merge + redeploy: curl /usage returns 200 with plan.currentSession.utilization populated

## Blocking None
Self-reviewed as hotfix; 3-line change with direct cli.js citation.