### PR TITLE
feat(ci): add model-watcher MVP (daily /v1/models diff -> auto PR)

### DIFF
--- a/.github/workflows/model-watcher.yml
+++ b/.github/workflows/model-watcher.yml
@@ -1,0 +1,66 @@
+name: Model Watcher
+on:
+  schedule:
+    - cron: '0 3 * * *'  # daily 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Fetch /v1/models
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          curl -sS https://api.anthropic.com/v1/models \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -o /tmp/models.json
+      - name: Diff against MODEL_MAP
+        run: node scripts/diff-models.mjs /tmp/models.json server.mjs > /tmp/diff.json
+      - name: Check if changes needed
+        id: check
+        run: |
+          ADDED=$(jq '.added | length' /tmp/diff.json)
+          REMOVED=$(jq '.removed | length' /tmp/diff.json)
+          echo "added=$ADDED" >> $GITHUB_OUTPUT
+          echo "removed=$REMOVED" >> $GITHUB_OUTPUT
+          if [ "$ADDED" -gt 0 ]; then echo "has_changes=true" >> $GITHUB_OUTPUT; fi
+      - name: Patch server.mjs
+        if: steps.check.outputs.has_changes == 'true'
+        run: node scripts/patch-server-mjs.mjs /tmp/diff.json server.mjs
+      - name: Save diff artifact
+        if: steps.check.outputs.has_changes == 'true'
+        run: cp /tmp/diff.json model-diff.json
+      - name: Open PR
+        if: steps.check.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: auto/model-watcher
+          commit-message: 'feat(models): auto-detected new model(s) from /v1/models'
+          title: 'feat(models): auto-detected new Claude model(s)'
+          body: |
+            Automated PR from model-watcher.
+
+            **Source**: `https://api.anthropic.com/v1/models` (snapshot attached as `model-diff.json`)
+
+            ### Added (auto-applied)
+            See diff — `MODEL_MAP` and `MODELS` updated.
+
+            ### ⚠️ Human decisions required
+            - [ ] Bump short alias `opus` / `sonnet` / `haiku` to new version?
+            - [ ] Deprecate any model in `removed` list?
+            - [ ] Version bump (minor if additive, major if removing)
+
+            ### Alignment evidence
+            Per ALIGNMENT.md Rule on model registry: this PR sources ids from Anthropic's official `/v1/models` endpoint.
+          labels: |
+            automation
+            models
+          delete-branch: true

--- a/scripts/diff-models.mjs
+++ b/scripts/diff-models.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// scripts/diff-models.mjs
+// Usage: node scripts/diff-models.mjs <models-json-path> <server-mjs-path>
+//
+// Reads Anthropic /v1/models response JSON and the server.mjs source,
+// then prints {added, removed} JSON to stdout.
+//
+// added   = canonical ids present in API but missing from MODEL_MAP
+// removed = canonical ids present in MODEL_MAP but missing from API
+//
+// Only canonical ids (matching /^claude-[a-z]+-\d/) are considered.
+// Short aliases like "opus", "sonnet", "haiku" are intentionally ignored —
+// bumping those is a human decision (surfaced in the PR body).
+
+import { readFileSync } from "node:fs";
+
+const CANONICAL_RE = /^claude-[a-z]+-\d/;
+
+function usage(msg) {
+  if (msg) console.error(msg);
+  console.error("usage: node scripts/diff-models.mjs <models-json-path> <server-mjs-path>");
+  process.exit(2);
+}
+
+const [, , modelsJsonPath, serverMjsPath] = process.argv;
+if (!modelsJsonPath || !serverMjsPath) usage();
+
+// ── 1. Parse Anthropic /v1/models payload ──────────────────────────────
+const apiPayload = JSON.parse(readFileSync(modelsJsonPath, "utf8"));
+const apiData = Array.isArray(apiPayload?.data) ? apiPayload.data : [];
+
+const apiModels = new Map(); // id → display_name
+for (const m of apiData) {
+  if (!m || typeof m.id !== "string") continue;
+  if (!CANONICAL_RE.test(m.id)) continue;
+  apiModels.set(m.id, m.display_name || m.id);
+}
+
+// ── 2. Extract MODEL_MAP keys and MODELS[].id from server.mjs ──────────
+const src = readFileSync(serverMjsPath, "utf8");
+
+function extractBlock(source, openMarker, openChar, closeChar) {
+  const startIdx = source.indexOf(openMarker);
+  if (startIdx < 0) return "";
+  const braceStart = source.indexOf(openChar, startIdx);
+  if (braceStart < 0) return "";
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === openChar) depth++;
+    else if (ch === closeChar) {
+      depth--;
+      if (depth === 0) return source.slice(braceStart, i + 1);
+    }
+  }
+  return "";
+}
+
+const mapBlock = extractBlock(src, "const MODEL_MAP = {", "{", "}");
+const modelsBlock = extractBlock(src, "const MODELS = [", "[", "]");
+
+const mapKeys = new Set();
+for (const m of mapBlock.matchAll(/"([^"]+)"\s*:/g)) {
+  const k = m[1];
+  if (CANONICAL_RE.test(k)) mapKeys.add(k);
+}
+
+const modelsIds = new Set();
+for (const m of modelsBlock.matchAll(/id\s*:\s*"([^"]+)"/g)) {
+  const k = m[1];
+  if (CANONICAL_RE.test(k)) modelsIds.add(k);
+}
+
+// Union of canonical ids already declared in server.mjs. A model is considered
+// "missing" only if neither structure knows it.
+const knownIds = new Set([...mapKeys, ...modelsIds]);
+
+// ── 3. Compute diff ────────────────────────────────────────────────────
+const added = [];
+for (const [id, display_name] of apiModels) {
+  if (!knownIds.has(id)) added.push({ id, display_name });
+}
+
+const removed = [];
+for (const id of knownIds) {
+  if (!apiModels.has(id)) removed.push(id);
+}
+
+process.stdout.write(JSON.stringify({ added, removed }, null, 2) + "\n");
+process.exit(0);

--- a/scripts/patch-server-mjs.mjs
+++ b/scripts/patch-server-mjs.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// scripts/patch-server-mjs.mjs
+// Usage: node scripts/patch-server-mjs.mjs <diff-json-path> <server-mjs-path>
+//
+// Reads the {added, removed} diff produced by diff-models.mjs and inserts
+// new canonical ids into MODEL_MAP and MODELS in server.mjs.
+//
+// Rules:
+//  - Only `added` entries are applied. `removed` is surfaced in the PR body
+//    as a human decision (deprecation is not auto-applied).
+//  - Short aliases (opus / sonnet / haiku) are never touched here — bumping
+//    them to a new version is a human decision.
+//  - Zero dependencies. Regex-based string insertion.
+//  - Existing 2-space indentation is preserved.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+function usage(msg) {
+  if (msg) console.error(msg);
+  console.error("usage: node scripts/patch-server-mjs.mjs <diff-json-path> <server-mjs-path>");
+  process.exit(2);
+}
+
+const [, , diffJsonPath, serverMjsPath] = process.argv;
+if (!diffJsonPath || !serverMjsPath) usage();
+
+const diff = JSON.parse(readFileSync(diffJsonPath, "utf8"));
+const added = Array.isArray(diff?.added) ? diff.added : [];
+
+if (added.length === 0) {
+  console.error("patch-server-mjs: no additions — nothing to do");
+  process.exit(0);
+}
+
+let src = readFileSync(serverMjsPath, "utf8");
+
+// ── 1. Insert into MODEL_MAP ───────────────────────────────────────────
+// Strategy: find the MODEL_MAP block, walk its lines, and insert new
+// `"<id>": "<id>",` lines after the last canonical-id line (before the
+// short aliases like "opus"/"sonnet"/"haiku").
+const CANONICAL_LINE_RE = /^(\s*)"(claude-[a-z]+-\d[^"]*)"\s*:\s*"[^"]+"\s*,?\s*$/;
+
+const mapOpen = src.indexOf("const MODEL_MAP = {");
+if (mapOpen < 0) {
+  console.error("patch-server-mjs: MODEL_MAP not found in server.mjs");
+  process.exit(1);
+}
+const mapBraceStart = src.indexOf("{", mapOpen);
+let depth = 0;
+let mapBraceEnd = -1;
+for (let i = mapBraceStart; i < src.length; i++) {
+  if (src[i] === "{") depth++;
+  else if (src[i] === "}") {
+    depth--;
+    if (depth === 0) { mapBraceEnd = i; break; }
+  }
+}
+if (mapBraceEnd < 0) {
+  console.error("patch-server-mjs: MODEL_MAP closing brace not found");
+  process.exit(1);
+}
+
+const mapBody = src.slice(mapBraceStart + 1, mapBraceEnd);
+const mapLines = mapBody.split("\n");
+
+// Find the index of the last line that declares a canonical id.
+let lastCanonicalIdx = -1;
+let indent = "  ";
+for (let i = 0; i < mapLines.length; i++) {
+  const m = mapLines[i].match(CANONICAL_LINE_RE);
+  if (m) {
+    lastCanonicalIdx = i;
+    indent = m[1] || "  ";
+  }
+}
+if (lastCanonicalIdx < 0) {
+  console.error("patch-server-mjs: no canonical-id line found in MODEL_MAP");
+  process.exit(1);
+}
+
+const newMapLines = [];
+for (const entry of added) {
+  newMapLines.push(`${indent}"${entry.id}": "${entry.id}",`);
+}
+mapLines.splice(lastCanonicalIdx + 1, 0, ...newMapLines);
+
+const patchedMapBody = mapLines.join("\n");
+src = src.slice(0, mapBraceStart + 1) + patchedMapBody + src.slice(mapBraceEnd);
+
+// ── 2. Insert into MODELS array ────────────────────────────────────────
+const modelsOpen = src.indexOf("const MODELS = [");
+if (modelsOpen < 0) {
+  console.error("patch-server-mjs: MODELS not found in server.mjs");
+  process.exit(1);
+}
+const arrStart = src.indexOf("[", modelsOpen);
+depth = 0;
+let arrEnd = -1;
+for (let i = arrStart; i < src.length; i++) {
+  if (src[i] === "[") depth++;
+  else if (src[i] === "]") {
+    depth--;
+    if (depth === 0) { arrEnd = i; break; }
+  }
+}
+if (arrEnd < 0) {
+  console.error("patch-server-mjs: MODELS closing bracket not found");
+  process.exit(1);
+}
+
+const arrBody = src.slice(arrStart + 1, arrEnd);
+const arrLines = arrBody.split("\n");
+
+// Find the last existing `{ id: "...", name: "..." }` line for indent reference
+let lastModelIdx = -1;
+let modelIndent = "  ";
+for (let i = 0; i < arrLines.length; i++) {
+  const m = arrLines[i].match(/^(\s*)\{\s*id\s*:\s*"[^"]+"/);
+  if (m) {
+    lastModelIdx = i;
+    modelIndent = m[1] || "  ";
+  }
+}
+
+const newModelLines = [];
+for (const entry of added) {
+  const name = (entry.display_name || entry.id).replace(/"/g, '\\"');
+  newModelLines.push(`${modelIndent}{ id: "${entry.id}", name: "${name}" },`);
+}
+
+if (lastModelIdx >= 0) {
+  arrLines.splice(lastModelIdx + 1, 0, ...newModelLines);
+} else {
+  // Empty MODELS — inject just before the closing bracket line.
+  arrLines.splice(arrLines.length - 1, 0, ...newModelLines);
+}
+
+const patchedArrBody = arrLines.join("\n");
+src = src.slice(0, arrStart + 1) + patchedArrBody + src.slice(arrEnd);
+
+writeFileSync(serverMjsPath, src);
+console.error(`patch-server-mjs: inserted ${added.length} model(s) into MODEL_MAP and MODELS`);


### PR DESCRIPTION
## Summary
- Daily cron polls Anthropic `/v1/models`, diffs vs `MODEL_MAP`
- Auto-opens PR when new canonical model ids appear
- Short-alias bump (opus/sonnet/haiku) + model deprecation stay human-gated

## Scope boundaries (P1 MVP)
- [x] Detect + auto-patch MODEL_MAP + MODELS for new ids
- [x] Human review required to merge
- [ ] No auto version bump (P2: release-please)
- [ ] No auto deploy (P2: tag-push -> ssh ocp update)

## Test plan
- [ ] Manual trigger via workflow_dispatch after merge to verify no false positives (current MODEL_MAP should match /v1/models)
- [ ] Simulate new model by temporarily removing one id from MODEL_MAP -> confirm PR opens

## Prereq
- Add `ANTHROPIC_API_KEY` to repo secrets before first run (otherwise curl fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)