### PR TITLE
chore(release): v3.11.0 — models.json SPOT + OpenClaw auto-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## v3.11.0 — 2026-04-20
+
+### Features
+- `ocp update` now automatically syncs OpenClaw's registry with the latest models (scripts/sync-openclaw.mjs)
+- Server logs warn if OpenClaw registry drifts from models.json
+
+### Refactor
+- models.json is now the single source of truth for model list
+- server.mjs and setup.mjs derive MODEL_MAP/MODELS from models.json
+- Adding a new model is now a one-file edit
+
+### Fixes
+- OpenClaw's model dropdown now shows all 4 current models (opus-4-7, opus-4-6, sonnet-4-6, haiku-4.5) on existing installs after `ocp update`. Previously setup.mjs only wrote the registry at install time.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-claude-proxy",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` version 3.10.0 → 3.11.0
- Adds `CHANGELOG.md` with the v3.11.0 entry

Rolls up #30 (refactor: models.json single-source-of-truth) and #31 (feat: idempotent OpenClaw registry sync + passive drift check).

## Test plan

- Alignment CI: passes (no server.mjs change in this PR)
- After merge, tag v3.11.0 and deploy to cloud via `ocp update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)