### PR TITLE
chore(governance): add release-kit overlay + PR self-check + auto-release workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,3 +38,10 @@ Reviewers: this section is for you, not the author. Do not approve until every b
 - `ALIGNMENT.md` Rule(s) invoked: <!-- e.g. Rule 3 -->
 - Related issue / prior PR: <!-- #NNN -->
 - Historical lesson reference (if relevant): <!-- e.g. 2026-04-11 drift, b87992f -->
+
+### User-visible change self-check (铁律第五律 5.3)
+
+- [ ] This PR has user-visible changes → README has corresponding documentation (paste diff link or line range)
+- [ ] This PR has no user-visible changes → stated "no user-visible change" in summary above
+
+Reviewers: if "user-visible" is checked but README diff is empty, block merge (per 5.3 reviewer gate).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Auto Release on Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Extract version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - name: Extract CHANGELOG section
+        id: notes
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          # Extract section for this version from CHANGELOG.md
+          # Pattern: "## v${VERSION}" through the next "## " or EOF
+          if [ ! -f CHANGELOG.md ]; then
+            echo "No CHANGELOG.md found; using minimal release notes"
+            echo "notes=Release v${VERSION}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          awk -v ver="v${VERSION}" '
+            $0 ~ "^## " ver { found=1; print; next }
+            found && /^## v/ { exit }
+            found { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "No matching section in CHANGELOG for v${VERSION}; using minimal notes"
+            echo "Release v${VERSION}" > /tmp/release-notes.md
+          fi
+          echo "notes_file=/tmp/release-notes.md" >> $GITHUB_OUTPUT
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "v${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
+            echo "Release v${{ steps.ver.outputs.version }} already exists — skipping"
+            exit 0
+          fi
+          gh release create "v${{ steps.ver.outputs.version }}" \
+            --title "v${{ steps.ver.outputs.version }}" \
+            --notes-file /tmp/release-notes.md \
+            --latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,36 @@ The full iron rules are at `~/.claude/CC_DEV_IRON_RULES.md` (symlinked from the 
 ## Project-level escalation
 
 If a design decision cannot be resolved by reference to `cli.js` and `ALIGNMENT.md`, escalate to Tao (老大) via `/cc-chat` rather than guessing. Silent guessing is what produced the 2026-04-11 drift.
+
+---
+
+## Release kit overlay (CC 开发铁律 第五律 5.5)
+
+This project's overlay per iron rule v1.4's 5.5. Machine-checkable declaration.
+
+```yaml
+release_kit:
+  version_source: package.json
+  changelog: CHANGELOG.md
+  release_channel:
+    type: github-release
+    tag_format: v{semver}
+    auto_create_on_tag_push: true   # via .github/workflows/release.yml
+  docs_source: README.md
+  resource_lists:
+    - name: Available Models table
+      location: README.md § "Available Models"
+      source_of_truth: models.json
+    - name: API Endpoints table
+      location: README.md § "API Endpoints"
+    - name: Environment Variables table
+      location: README.md § "Environment Variables"
+  new_feature_doc_expectations:
+    - new CLI subcommand → README § "All Commands" + usage example
+    - new env var → README § "Environment Variables" table
+    - new auto-sync / hook → dedicated §, must document trigger + manual invocation + opt-out + any bootstrap quirk
+    - new endpoint → README § "API Endpoints" table + any relevant Config/Troubleshooting §
+    - new file / SPOT / schema → Architecture or contributor § with link
+  bootstrap_quirk_policy:
+    - any one-time migration quirk → README § "Troubleshooting"
+```


### PR DESCRIPTION
## Summary
Implements cc-rules v1.4's 第五律 5.5 overlay + 5.3 PR self-check + 5.2 auto-release (the machine-tended gap that caused v3.9/v3.10/v3.11 to each miss GH Release).

## Changes
- \`CLAUDE.md\` — append release-kit overlay YAML block
- \`.github/PULL_REQUEST_TEMPLATE.md\` — append 5.3 self-check section
- \`.github/workflows/release.yml\` (NEW) — auto-release on tag push, sources notes from CHANGELOG.md

## User-visible change self-check (新规则应用本 PR)
- [x] No user-visible change — this is governance only. No README update needed.

## Test plan
- [x] Locally tested awk CHANGELOG extractor against v3.11.0 section
- [ ] Next release will confirm workflow fires correctly (cannot test on this PR since it has no tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)