### PR TITLE
fix(concurrency): release slot on subprocess SIGTERM failure (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.11.1 — 2026-04-21
+
+### Fixes
+- Concurrency slot leak on subprocess timeout (#37). The request-timeout handler called `proc.kill("SIGTERM")` without decrementing `stats.activeRequests`. A subprocess stuck in a syscall that ignored SIGTERM would hold its slot until (or beyond) the 5s SIGKILL escalation actually reaped it. Slot release is now wired to `proc.once("exit", cleanup)` so every termination path — normal close, error, SIGTERM, SIGKILL — releases the slot exactly once.
+
 ## v3.11.0 — 2026-04-20
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-claude-proxy",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {

--- a/server.mjs
+++ b/server.mjs
@@ -444,6 +444,15 @@ function spawnClaudeProcess(model, messages, conversationId) {
     stats.activeRequests--;
   }
 
+  // Guarantee slot release on ANY exit path (normal close, error, timeout kill,
+  // SIGKILL escalation). The 'exit' event fires before 'close' and runs even
+  // if stdio pipes stay open. Fixes #37: the timeout path called
+  // proc.kill('SIGTERM') without decrementing the concurrency counter, so a
+  // stuck subprocess that ignored SIGTERM could leak its slot until (or
+  // beyond) the SIGKILL escalation actually reaped it. cleanup() is idempotent
+  // so this listener is safe alongside the existing 'close'/'error' paths.
+  proc.once("exit", cleanup);
+
   function handleSessionFailure() {
     if (sessionInfo?.resume && conversationId) {
       console.warn(`[session] resume failed for ${conversationId.slice(0, 12)}..., removing stale session`);


### PR DESCRIPTION
## Problem

**Symptom** (from #37): Mac mini OCP returned `500 concurrency limit reached (8/8)` every day. Diagnostic snapshot captured 3 stuck `claude` subprocesses holding slots for 20 min to 2h 45m, exhausting the 8-slot pool.

**Root cause** (verified in v3.11.0 `server.mjs:471-480`): the request-timeout handler fired `proc.kill("SIGTERM")` but did NOT decrement `stats.activeRequests`. Slot release was entirely deferred to `proc.on("close")` (lines 508-524, 589-631). For a subprocess stuck in a syscall that ignores SIGTERM, the slot was only released when the 5s SIGKILL escalation eventually reaped the child — and only if `'close'` actually fired. In pathological cases (D-state kernel wait, delayed stdio pipe close, or any other path where `'close'` never fires) the slot leaks permanently.

## Fix

One-line addition in `spawnClaudeProcess()`:

```js
proc.once("exit", cleanup);
```

The `'exit'` event fires before `'close'` and runs on every termination path — normal exit, error, SIGTERM, SIGKILL, crash — independent of stdio pipe state. `cleanup()` is already idempotent (guarded by `cleaned`), so this coexists safely with the existing `'close'`/`'error'` paths that also call it.

Smallest possible diff (+8 lines comment, +1 line listener). No refactor, no behavior change on the happy path.

## ALIGNMENT.md compliance

**Rule 1 (Grep First)**: `cli.js` grepped for `maxConcurrent` / `concurrency` / subprocess-pool patterns — no equivalent logic found. `cli.js` is a single-user CLI; it is the process being pooled, not the pool itself. (Note: local install is `@anthropic-ai/claude-code@2.1.116`, which ships a native Mach-O binary `claude.exe` rather than a `cli.js` bundle — an ALIGNMENT audit-pin drift from the 2.1.89 pin, out of scope for this PR.)

**Rule 2 (No Invention) — justification**: This fix is proxy-internal (subprocess lifecycle / concurrency-pool management) with no `cli.js` equivalent. Per ALIGNMENT.md Rule 2, documented here instead of cited.

**Rule 3 (Match Implementation)**: no change to wire protocol, HTTP API surface, response shape, headers, or request schema. Pure internal lifecycle fix.

## Iron Rule 10 — independent reviewer required

**DO NOT self-approve.** Per CC Iron Rule 10 this PR requires an independent reviewer before merge. The reviewer should verify:

1. `proc.once("exit", cleanup)` placement is correct (after `cleanup` is declared, before any path that could `return`).
2. `cleanup()` idempotency guard (`if (cleaned) return;`) genuinely makes double-call safe.
3. No new `'exit'` handler conflicts with the existing `'close'` handlers in `callClaude` (line 508) or `callClaudeStreaming` (line 589).
4. Manual verification plan below is sufficient, or request a regression test.

## Iron Rule 5.3 — Release Kit self-check

- [x] Version bumped `3.11.0` → `3.11.1` in `package.json` (patch bump — bugfix, no API change)
- [x] CHANGELOG entry added under `## v3.11.1 — 2026-04-21`
- [x] README version references audited — all refer to v3.11.0 as the feature-gate baseline for models.json SPOT / auto-sync, historically accurate; N/A for bugfix bump
- [x] Release procedure: after merge, push tag `v3.11.1` to trigger `release.yml` (which runs on `push: tags: v*`).

## Test plan

**No automated regression test added** — `test-features.mjs` exercises the `keys.mjs` DB layer only; adding a hung-subprocess concurrency test would require new mock-child infrastructure, out of IDR scope for this PR. File a follow-up issue if desired.

**Manual verification on Mac mini after merge + deploy of v3.11.1**:

1. `launchctl` restart OCP to pick up new code (separately — not part of this PR).
2. Trigger a timeout by sending a request with `TIMEOUT` env set low (e.g. 5s) against an opus `xhigh` model that will exceed it.
3. Check `/health` endpoint: `activeRequests` should decrement to `0` within `TIMEOUT + 5s` (SIGKILL budget), not wait indefinitely.
4. Repeat 8 times rapidly to confirm slots fully recycle and no `concurrency limit reached` error surfaces on the 9th request.
5. Watch `logEvent("error", "request_timeout", ...)` log line: timestamp of the error vs. timestamp of the next successful `claude_spawned` should be `< TIMEOUT + 5s`.

## Scope (Iron Rule 11 — IDR)

This PR fixes the timeout-cleanup slot leak **only**. Secondary findings during the forensic pass (e.g. `handleSessionFailure` only fires on `resume: true`, SESSION_TTL vs. `lastUsed` interaction) are separate concerns and, if confirmed bugs, will be filed as separate issues and PRs.

Fixes #37.

---
## Reviewer follow-ups
- Filed: #41 (handleSessionFailure resume-only scope)
- Filed: #42 (SESSION_TTL vs lastUsed staleness)
- Pre-existing TDZ risk in `cleanup()` referencing `overallTimer` declared later — out of scope for this PR (per IDR).
- ALIGNMENT audit-pin refresh (2.1.89 → 2.1.116) tracked separately.
