### PR TITLE
chore(repo): standardize maintainer refs to role-based across docs

### DIFF
--- a/ALIGNMENT.md
+++ b/ALIGNMENT.md
@@ -44,7 +44,7 @@ OCP (Open Claude Proxy) is a **proxy layer** for the Claude Code CLI. It forward
 - **Claude Code version under audit:** `2.1.89`
 - **`cli.js` SHA-256:** `a9950ef6407fdc750bddb673852485500387e524a99d42385cb81e7d17128e01`
 - **Audit date:** `2026-04-20`
-- **Auditor:** `Tao Deng`
+- **Auditor:** `project maintainer`
 
 The audit pin is updated once per year (see Annual Alignment Audit) and whenever a drift incident forces a re-verification.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ This repo operates under the CC Development Iron Rules (CC 开发铁律) v1.3. T
 - **Iron Rule 11 (Incremental Diff Review).** Non-trivial work is split into the minimum reviewable unit — one PR per layer per severity. `ALIGNMENT.md`, `CLAUDE.md`, the PR template, and the CI workflow are therefore shipped as the same constitutional PR (they are one layer: governance), but any subsequent `server.mjs` remediation lands as its own PR.
 - **Iron Rule 12 (Pre-Brainstorm Prior-Art Search).** Before proposing any new endpoint or header, search GitHub, Anthropic docs, and the `cli.js` bundle. For OCP specifically, the `cli.js` grep is the decisive search: if it does not hit, Rule 2 of the constitution applies.
 
-The full iron rules are at `~/.claude/CC_DEV_IRON_RULES.md` (symlinked from the cc-rules repo on Tao's workstations). Load them into session context with `/cc-rules` when needed.
+The full iron rules are at `~/.claude/CC_DEV_IRON_RULES.md` (symlinked from the cc-rules repo on the maintainer's workstations). Load them into session context with `/cc-rules` when needed.
 
 ---
 
@@ -58,7 +58,7 @@ The full iron rules are at `~/.claude/CC_DEV_IRON_RULES.md` (symlinked from the 
 
 ## Project-level escalation
 
-If a design decision cannot be resolved by reference to `cli.js` and `ALIGNMENT.md`, escalate to Tao (老大) via `/cc-chat` rather than guessing. Silent guessing is what produced the 2026-04-11 drift.
+If a design decision cannot be resolved by reference to `cli.js` and `ALIGNMENT.md`, escalate to the project maintainer via `/cc-chat` rather than guessing. Silent guessing is what produced the 2026-04-11 drift.
 
 ---
 

--- a/docs/adr/0002-alignment-constitution.md
+++ b/docs/adr/0002-alignment-constitution.md
@@ -2,7 +2,7 @@
 
 - **Date**: 2026-04-20
 - **Status**: Accepted
-- **Authors**: Tao Deng, Claude Opus 4.7 (drafting)
+- **Authors**: project maintainer (with AI drafting assistance)
 - **Related**: PR #20, commit 2853088; supersedes implicit "keep the proxy honest" discipline
 
 ## Context
@@ -37,7 +37,7 @@ Supporting mechanisms:
 - `CLAUDE.md` enshrines hard requirements for `server.mjs` PRs: `cli.js` citation, CI blacklist pass, independent reviewer who opens `cli.js` at the cited lines.
 - `.github/workflows/alignment.yml` greps `server.mjs` on every PR for the known-hallucinated token set (`api/oauth/usage`, `api/usage`, et al.) and fails the build on any hit.
 - `.github/PULL_REQUEST_TEMPLATE.md` makes the `cli.js` citation and the reviewer's cli.js-opened confirmation mandatory fields.
-- A bootstrap audit pin: Claude Code `2.1.89`, `cli.js` SHA-256 `a9950ef6407fdc750bddb673852485500387e524a99d42385cb81e7d17128e01`, auditor Tao Deng, date 2026-04-20. The pin is refreshed annually on 11 April (the drift anniversary) or on any re-verification event.
+- A bootstrap audit pin: Claude Code `2.1.89`, `cli.js` SHA-256 `a9950ef6407fdc750bddb673852485500387e524a99d42385cb81e7d17128e01`, auditor: project maintainer, date 2026-04-20. The pin is refreshed annually on 11 April (the drift anniversary) or on any re-verification event.
 - A documented Historical Lesson section in `ALIGNMENT.md` that names the drift commits by SHA, so the incident cannot be rewritten or quietly forgotten.
 
 ## Consequences
@@ -63,7 +63,7 @@ Supporting mechanisms:
 
 ## Alternatives considered
 
-**(a) Pure human discipline — no CI, no template, no ADR.** Tao would simply commit to grepping `cli.js` on every change, and reviewers would commit to verifying. Rejected: the 2026-04-11 drift already happened under exactly this regime. Tao is meticulous, and the drift still shipped. Social discipline alone cannot prevent LLM hallucination from slipping through, especially when the LLM's output is superficially plausible.
+**(a) Pure human discipline — no CI, no template, no ADR.** the maintainer would simply commit to grepping `cli.js` on every change, and reviewers would commit to verifying. Rejected: the 2026-04-11 drift already happened under exactly this regime. the maintainer is meticulous, and the drift still shipped. Social discipline alone cannot prevent LLM hallucination from slipping through, especially when the LLM's output is superficially plausible.
 
 **(b) Automatic `cli.js` diff on every PR.** A CI step that diffs `server.mjs`'s network surface against a parsed `cli.js` AST, blocking on any mismatch. Rejected as too fragile: `cli.js` v2.1.90+ ships as a minified/obfuscated binary, making AST-level grep invalid without an unofficial unbundling step. Any such pipeline becomes a maintenance burden on Anthropic's release cadence, and would routinely false-positive. The blacklist approach is lower-precision but dramatically more robust.
 

--- a/docs/adr/0003-models-json-spot.md
+++ b/docs/adr/0003-models-json-spot.md
@@ -2,7 +2,7 @@
 
 - **Date**: 2026-04-20
 - **Status**: Accepted
-- **Authors**: Tao Deng, Claude Opus 4.7 (drafting)
+- **Authors**: project maintainer (with AI drafting assistance)
 - **Related**: PR #30, commit c6f7850; precursor to ADR 0004
 
 ## Context

--- a/docs/adr/0004-openclaw-auto-sync.md
+++ b/docs/adr/0004-openclaw-auto-sync.md
@@ -2,7 +2,7 @@
 
 - **Date**: 2026-04-20
 - **Status**: Accepted
-- **Authors**: Tao Deng, Claude Opus 4.7 (drafting)
+- **Authors**: project maintainer (with AI drafting assistance)
 - **Related**: PR #31, commit 5ef163a; builds on ADR 0003
 
 ## Context

--- a/docs/superpowers/plans/2026-04-10-lan-mode.md
+++ b/docs/superpowers/plans/2026-04-10-lan-mode.md
@@ -31,7 +31,7 @@
 - [ ] **Step 1: Install better-sqlite3**
 
 ```bash
-cd /Users/taodeng/.openclaw/projects/claude-proxy
+cd $HOME/.openclaw/projects/claude-proxy
 npm install better-sqlite3
 ```
 
@@ -1085,7 +1085,7 @@ git commit -m "docs: add LAN mode documentation and family sharing guide"
 - [ ] **Step 1: Start OCP in LAN mode with multi-key auth**
 
 ```bash
-cd /Users/taodeng/.openclaw/projects/claude-proxy
+cd $HOME/.openclaw/projects/claude-proxy
 CLAUDE_BIND=0.0.0.0 CLAUDE_AUTH_MODE=multi OCP_ADMIN_KEY=test-admin-123 node server.mjs &
 sleep 3
 ```

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -45,6 +45,6 @@ work-state file.
 
 This constitution is subordinate to `AGENTS.md` for project-specific memory policy
 and to CC 开发铁律 for development discipline. Amendments require a PR reviewed by
-the project maintainer (Tao Deng).
+the project maintainer.
 
 **Version**: 1.0.0 | **Ratified**: 2026-04-21 | **Last Amended**: 2026-04-21


### PR DESCRIPTION
## Summary

Standardizes how the project maintainer is referenced across this public repo's documentation. Previously a mix of inline names, nicknames, and literal home-directory paths; now uses role-based wording (`the project maintainer`, `the user`, `$HOME/`, `the project`) consistently. This is repo-hygiene work so future contributions land against a clean style baseline.

## What changed

- Replaced personal-name references → `project maintainer` (6 files)
- Replaced informal nickname references → `the project maintainer` / removed where unnecessary (2 files)
- Replaced personal hostnames → role-based hostnames (`home-mac`, `travel-macbook`) in untracked ADR 0001
- Replaced literal home-directory paths → `$HOME/` (2 instances in old plan docs)

## Files touched

- `CLAUDE.md`
- `ALIGNMENT.md`
- `docs/adr/0002-alignment-constitution.md`
- `docs/adr/0003-models-json-spot.md`
- `docs/adr/0004-openclaw-auto-sync.md`
- `memory/constitution.md`
- `docs/superpowers/plans/2026-04-10-lan-mode.md`

## Why now

This repo is public. Role-based references read better for contributors arriving from outside, document the project as a project (not a person), and remove unnecessary identifiability. Future agent-assisted contributions match the same convention by default once `AGENTS.md` is updated to require it (tracked in #44).

## Scope (non-)

This PR touches the current tree only. Git history is untouched — historical commits authored before this convention was adopted retain their original wording. Rewriting history was considered and declined: the cost (broken clones, broken PR refs) is higher than the marginal benefit for non-secret content. See #44 for the policy reasoning.

## User-visible change self-check (铁律第五律 5.3)

- [x] Docs/governance only. README not directly affected. No end-user behavior change.

## Follow-ups

Tracked in #44 (policy + tooling) and #45 (gitleaks config + PR template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
