### PR TITLE
chore(repo): add gitleaks config + PR checklist for maintainer refs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,3 +45,12 @@ Reviewers: this section is for you, not the author. Do not approve until every b
 - [ ] This PR has no user-visible changes → stated "no user-visible change" in summary above
 
 Reviewers: if "user-visible" is checked but README diff is empty, block merge (per 5.3 reviewer gate).
+
+### Privacy self-check (for PUBLIC repos) — Iron Rule adjacent
+
+- [ ] This PR does not introduce real names, nicknames, or handles that identify specific individuals. All references use role-based terms (`project maintainer`, `contributor`, `user`, `reviewer`).
+- [ ] This PR does not introduce literal personal paths (`/Users/<username>/`, `/home/<username>/`). Uses `$HOME/` or `~/` instead.
+- [ ] This PR does not introduce personal machine hostnames. Uses role-based names or generic descriptors.
+- [ ] This PR does not introduce personal email addresses beyond automated placeholders like `noreply@<vendor>.com`.
+
+Reviewers: if any of the above is violated and the repo is PUBLIC, block merge and request scrub.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+title = "OCP gitleaks configuration"
+
+[allowlist]
+description = "OCP known-safe allowlist"
+regexes = [
+  # Public OAuth client ID for Claude Code PKCE flow (constant, not a secret)
+  '''9d1c250a-e61b-44d9-88ed-5944d1962f5e''',
+  # OCP README API key placeholder example
+  '''ocp_(example|XXX+|xxxx+)''',
+]
+paths = [
+  # Old plan doc with test-admin-123 placeholders
+  '''docs/superpowers/plans/2026-04-10-lan-mode\.md''',
+]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ export OCP_ADMIN_KEY=your-secret-admin-key
 
 ocp keys add wife-laptop
 #  ✓ Key created for "wife-laptop"
-#    API Key: ocp_xDYzOB9ZKYzn...
+#    API Key: ocp_example12345abcde...
 #    Copy this key now — you won't see it again.
 
 ocp keys add son-ipad


### PR DESCRIPTION
## Summary

Adds proactive repo-hygiene tooling so public-repo conventions (role-based maintainer references, no literal personal paths, no ambiguous secret-shaped placeholders) are enforced mechanically rather than caught in review. Closes the tooling track of #44.

No code or runtime behavior change — config, docs, README placeholder, PR template only.

---

## Task 1 — `OAUTH_CLIENT_ID` classification: PUBLIC, not a secret

**Evidence:**

```js
// server.mjs line 696
const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
```

This is the OAuth PKCE **public client ID** used by the Claude Code CLI for its token-refresh flow. In OAuth 2.0 PKCE (RFC 7636), public clients have no `client_secret` — the `client_id` is intentionally public and is embedded in the CLI bundle itself. The value was introduced in commit `b87992f` mirroring what `cli.js` uses for its OAuth flow. A public client ID has zero exploitability: it cannot be used to obtain tokens without the corresponding PKCE `code_verifier` generated per-session on the user's machine.

**Conclusion**: public Claude Code OAuth client ID. `gitleaks` allowlist entry added so future scans don't false-positive on it.

---

## Task 2 — README.md API key placeholder hardening

**Before:**
```
#    API Key: ocp_xDYzOB9ZKYzn...
```

**After:**
```
#    API Key: ocp_example12345abcde...
```

`ocp_` IS the real key prefix (confirmed in `keys.mjs` line 80: `"ocp_" + randomBytes(24).toString("base64url")`). The original example used a real-looking prefix with a plausibly truncated base64url suffix — ambiguous to readers and flagged by `gitleaks`. The new placeholder is obviously synthetic.

---

## Task 3 — PR template: Privacy self-check section

Adds a `### Privacy self-check (for public repos)` section below the existing `### User-visible change self-check (铁律第五律 5.3)` section. Four checklist items covering: personal identifiers, literal paths, hostnames, personal email addresses. Reviewer gate included.

This makes the role-based-references convention visible to every contributor at PR-open time.

---

## Task 4 — `.gitleaks.toml` (new file)

Creates `.gitleaks.toml` with:
- Allowlist regex for the `OAUTH_CLIENT_ID` UUID (public constant)
- Allowlist regex for `ocp_(example|XXX+|xxxx+)` placeholders
- Allowlist path for `docs/superpowers/plans/2026-04-10-lan-mode.md` (known synthetic placeholders)

Verified: `gitleaks dir . --no-banner` → no leaks found after these changes.

---

## Reusable across other public repos

The `gitleaks.toml` patterns and the PR template "Privacy self-check" section are intentionally generic — portable to any public repo without OCP-specific edits.

---

## Claude Code Alignment Evidence

- [x] **No `cli.js` citation required.** This PR does not touch `server.mjs`. Docs / governance / config only.

## Type of change

- [x] Documentation / governance / config

## Reviewer checklist

- [ ] N/A — no `server.mjs` change
- [ ] I ran (or confirmed CI ran) `.github/workflows/alignment.yml` and it passed.
- [ ] I am not the commit author of any commit in this PR (Iron Rule 10).
- [ ] If the PR asserts scope without a `cli.js` citation, I confirmed the justification is sound per `ALIGNMENT.md` Rule 2.

## Related

- `ALIGNMENT.md` Rule(s) invoked: Rule 2 (no `server.mjs` change, docs only)
- Related: #44 (policy), #43 (current-tree cleanup)

### User-visible change self-check (铁律第五律 5.3)

- [x] User-visible change → README updated
  - README.md line 86: API key example changed from `ocp_xDYzOB9ZKYzn...` to `ocp_example12345abcde...`

### Privacy self-check (for public repos)

- [x] No real names, nicknames, or handles that identify individuals. All references are role-based.
- [x] No literal personal paths. Uses `$HOME/` or `~/`.
- [x] No personal machine hostnames.
- [x] No personal email addresses beyond automated placeholders.
