### PR TITLE
chore(speckit): add compatibility/metadata frontmatter to 9 SKILL.md files (#39)

### DIFF
--- a/.claude/skills/speckit-analyze/SKILL.md
+++ b/.claude/skills/speckit-analyze/SKILL.md
@@ -4,6 +4,10 @@ description: Perform a non-destructive cross-artifact consistency and quality an
 argument-hint: "Optional focus areas for analysis"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/analyze.md
 ---
 
 ## User Input

--- a/.claude/skills/speckit-checklist/SKILL.md
+++ b/.claude/skills/speckit-checklist/SKILL.md
@@ -4,6 +4,10 @@ description: Generate a custom checklist for the current feature based on user r
 argument-hint: "Domain or focus area for the checklist"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/checklist.md
 ---
 
 ## Checklist Purpose: "Unit Tests for English"

--- a/.claude/skills/speckit-clarify/SKILL.md
+++ b/.claude/skills/speckit-clarify/SKILL.md
@@ -4,6 +4,10 @@ description: Identify underspecified areas in the current feature spec by asking
 argument-hint: "Optional areas to clarify in the spec"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/clarify.md
 ---
 
 ## User Input

--- a/.claude/skills/speckit-constitution/SKILL.md
+++ b/.claude/skills/speckit-constitution/SKILL.md
@@ -4,6 +4,10 @@ description: Create or update the project constitution from interactive or provi
 argument-hint: "Principles or values for the project constitution"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/constitution.md
 ---
 
 ## User Input

--- a/.claude/skills/speckit-implement/SKILL.md
+++ b/.claude/skills/speckit-implement/SKILL.md
@@ -4,6 +4,10 @@ description: Execute the implementation plan by processing and executing all tas
 argument-hint: "Optional implementation guidance or task filter"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/implement.md
 ---
 
 ## User Input

--- a/.claude/skills/speckit-plan/SKILL.md
+++ b/.claude/skills/speckit-plan/SKILL.md
@@ -4,6 +4,10 @@ description: Execute the implementation planning workflow using the plan templat
 argument-hint: "Optional guidance for the planning phase"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/plan.md
 ---
 
 ## User Input

--- a/.claude/skills/speckit-specify/SKILL.md
+++ b/.claude/skills/speckit-specify/SKILL.md
@@ -4,6 +4,10 @@ description: Create or update the feature specification from a natural language 
 argument-hint: "Describe the feature you want to specify"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/specify.md
 ---
 
 ## User Input

--- a/.claude/skills/speckit-tasks/SKILL.md
+++ b/.claude/skills/speckit-tasks/SKILL.md
@@ -4,6 +4,10 @@ description: Generate an actionable, dependency-ordered tasks.md for the feature
 argument-hint: "Optional task generation constraints"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/tasks.md
 ---
 
 ## User Input

--- a/.claude/skills/speckit-taskstoissues/SKILL.md
+++ b/.claude/skills/speckit-taskstoissues/SKILL.md
@@ -4,6 +4,10 @@ description: Convert existing tasks into actionable, dependency-ordered GitHub i
 argument-hint: "Optional filter or label for GitHub issues"
 user-invocable: true
 disable-model-invocation: false
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: github-spec-kit
+  source: claude:templates/commands/taskstoissues.md
 ---
 
 ## User Input


### PR DESCRIPTION
## Summary

Backfills the two YAML frontmatter blocks (`compatibility`, `metadata`) that upstream `specify_cli/agents.py:build_skill_frontmatter()` emits, on all 9 speckit-* SKILL.md files. Closes #39.

Pure additive — each file gets +4 lines, no existing fields modified, no functional change. Per #39 body, these fields are informational/provenance only and not consumed by Claude Code's slash-command runtime.

## Claude Code Alignment Evidence

- [x] **`cli.js` reference.** N/A — does not touch `server.mjs` or any network-facing surface. Pure documentation/metadata in `.claude/skills/*/SKILL.md`.
- [x] **Commit message citations.** Single commit; body cites upstream `specify_cli/agents.py:build_skill_frontmatter()` as the canonical source.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation / governance (frontmatter metadata)

## Reviewer checklist

- [x] No `server.mjs` changes — Iron Rule 10's `cli.js`-citation gate not applicable.
- [ ] CI alignment.yml run — pending CI (should pass; no server.mjs touched).
- [x] Author not self-merging — awaiting maintainer review.

## Related

- Issue #39 (chore — opened 2026-04-21 from PR #38 reviewer finding)
- Upstream canonical format: [`specify_cli/agents.py:build_skill_frontmatter()`](https://github.com/github/spec-kit/blob/main/src/specify_cli/agents.py)

### User-visible change self-check

- [x] No user-visible change — frontmatter fields are informational, not consumed by slash-command runtime per #39.

### Privacy self-check

- [x] No real names / handles introduced (only `github-spec-kit` as upstream author)
- [x] No literal personal paths
- [x] No personal machine hostnames
- [x] No personal email addresses

## Verification

```
$ /usr/bin/grep -l '^compatibility:' .claude/skills/speckit-*/SKILL.md | wc -l
9
$ /usr/bin/grep -l '^metadata:' .claude/skills/speckit-*/SKILL.md | wc -l
9
$ /usr/bin/grep -l '^  author: github-spec-kit$' .claude/skills/speckit-*/SKILL.md | wc -l
9
$ /usr/bin/grep -lE '^  source: claude:templates/commands/(analyze|checklist|clarify|constitution|implement|plan|specify|tasks|taskstoissues)\.md$' .claude/skills/speckit-*/SKILL.md | wc -l
9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)