### PR TITLE
chore(server): session-failure + lifetime instrumentation (refs #41 #42)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -165,9 +165,18 @@ const sessions = new Map(); // conversationId → { uuid, messageCount, lastUsed
 const sessionCleanupInterval = setInterval(() => {
   const now = Date.now();
   for (const [id, s] of sessions) {
-    if (now - s.lastUsed > SESSION_TTL) {
+    const idleMs = now - s.lastUsed;
+    const ageMs = s.firstSeen ? now - s.firstSeen : null;
+    if (idleMs > SESSION_TTL) {
       sessions.delete(id);
-      console.log(`[session] expired ${id.slice(0, 12)}... (idle ${Math.round((now - s.lastUsed) / 60000)}m)`);
+      console.log(`[session] expired ${id.slice(0, 12)}... (idle ${Math.round(idleMs / 60000)}m)`);
+      logEvent("info", "session_expired", { conversationId: id.slice(0, 12) + "...", idleMs, ageMs });
+    } else if (ageMs !== null && ageMs > 4 * SESSION_TTL) {
+      // #42 evidence-gathering: a session whose firstSeen is more than 4× TTL old
+      // but whose lastUsed keeps getting bumped (never idle long enough to expire)
+      // is the suspected bug. Log without action so the pattern can be confirmed
+      // in /logs. Do NOT enforce an absolute age cap here speculatively.
+      logEvent("warn", "session_long_lived", { conversationId: id.slice(0, 12) + "...", idleMs, ageMs });
     }
   }
 }, 60000);
@@ -406,7 +415,8 @@ function spawnClaudeProcess(model, messages, conversationId) {
 
   } else if (conversationId) {
     const uuid = randomUUID();
-    sessions.set(conversationId, { uuid, messageCount: messages.length, lastUsed: Date.now(), model: cliModel });
+    const now = Date.now();
+    sessions.set(conversationId, { uuid, messageCount: messages.length, firstSeen: now, lastUsed: now, model: cliModel });
     sessionInfo = { uuid, resume: false };
     stats.sessionMisses++;
     prompt = messagesToPrompt(messages);
@@ -458,7 +468,13 @@ function spawnClaudeProcess(model, messages, conversationId) {
   function handleSessionFailure() {
     if (sessionInfo?.resume && conversationId) {
       console.warn(`[session] resume failed for ${conversationId.slice(0, 12)}..., removing stale session`);
+      logEvent("warn", "session_failure", { mode: "resume", conversationId: conversationId.slice(0, 12) + "...", action: "deleted" });
       sessions.delete(conversationId);
+    } else if (sessionInfo && !sessionInfo.resume && conversationId) {
+      // #41 evidence-gathering: session-create failures currently leave a stale entry
+      // in the sessions map. Log without action so the staleness pattern can be
+      // confirmed in /logs before any code change. Do NOT delete here speculatively.
+      logEvent("warn", "session_failure", { mode: "create", conversationId: conversationId.slice(0, 12) + "...", action: "kept" });
     }
   }
 


### PR DESCRIPTION
## Summary

Adds structured logging for #41 (session-create failures leave stale entries) and #42 (SESSION_TTL never expires when `lastUsed` is bumped on every reference). **This PR does not fix either bug.** Both issue bodies say "Evidence needed before code change — do not patch speculatively." This PR makes the suspected patterns observable in `/logs` so the eventual fixes can be evidence-driven.

## Claude Code Alignment Evidence

- [x] **`cli.js` reference: N/A.** `logEvent` payloads (`firstSeen`, `idleMs`, `ageMs`, `mode`, `action`) are OCP-internal observability — never sent to Anthropic's API on the wire. Per `ALIGNMENT.md` Rule 2, scope is endpoints/headers/request/response fields, not server-internal logging.
- [x] **Commit message citations.** Single commit; cli.js citation = N/A is stated explicitly in the commit body.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor (instrumentation; no behavior change)
- [ ] Deletion
- [ ] Documentation / governance

## Reviewer checklist

- [x] No `cli.js` operation introduced — pure observability layer.
- [ ] CI alignment.yml run — pending.
- [x] Author not self-merging — fresh-context sonnet reviewer ran (verdict: APPROVE_WITH_MINOR), maintainer reviews before merge.
- [x] Scope justification per `ALIGNMENT.md` Rule 2: internal logging is not a network surface change.

## Three changes

1. **`firstSeen` field on session create** (server.mjs:~417). Both `firstSeen` and `lastUsed` set to the same `now`. Resume branch untouched, so `firstSeen` is preserved across resumes. Pre-existing in-memory entries without the field are handled (sweep code uses `s.firstSeen ? ... : null`).

2. **`handleSessionFailure` emits structured `session_failure` event** (server.mjs:~470-477). `mode: "resume"` action: "deleted" matches existing `console.warn` + delete behavior. `mode: "create"` action: "kept" makes #41's "stale-on-create-failure" pattern observable without taking action. **No `sessions.delete(...)` added** in the create branch — that would be the speculative fix #41 explicitly forbids until evidence is gathered.

3. **TTL sweep emits two events** (server.mjs:~167-181):
   - `session_expired` (info) on actual expiry, with `idleMs` and `ageMs` for forensic correlation.
   - `session_long_lived` (warn) when `ageMs > 4 × SESSION_TTL` AND the entry is **not** being expired. This is the #42 evidence signal — `lastUsed` keeps getting bumped so idle-based expiry never fires.
   **No absolute age cap is enforced** — that would be the speculative fix #42 explicitly forbids.

## Independent review

Fresh-context `sonnet` reviewer (separate from author), 8-item checklist:
- VERDICT: **APPROVE_WITH_MINOR**
- All eight checks PASS (scope/firstSeen/handleSessionFailure log/TTL log/ALIGNMENT/no-regressions/LOC/privacy).
- Two non-blocking minor notes:
  - `session_long_lived` will fire every 60s per long-lived session — intentional for evidence-gathering, but downstream log analysis should dedupe by `conversationId` when measuring frequency.
  - Verified the `console.log(...(now - s.lastUsed)...)` → `console.log(...idleMs...)` substitution preserves prior format (`Math.round(... / 60000)`).

## Verification

```
$ cd ~/ocp && node -c server.mjs
(exit 0)

$ git diff main...chore/41-42-session-instrumentation --stat
 server.mjs | 22 +++++++++++++++++++---
 1 file changed, 19 insertions(+), 3 deletions(-)

$ git diff main...chore/41-42-session-instrumentation -- server.mjs | grep -iE 'api/oauth/usage|api/usage'
(empty — blacklist clean)
```

### User-visible change self-check

- [x] No user-visible change. New log fields surface in `GET /logs` only; no new env vars, no new endpoints, no SSE/wire-shape change.

### Privacy self-check

- [x] No real names / handles introduced.
- [x] No literal personal paths.
- [x] No personal machine hostnames.
- [x] No personal email addresses (only `noreply@anthropic.com` in Co-Authored-By trailer).
- [x] All new log payloads slice `conversationId` to 12 chars + `...` matching existing convention.

## Related

- Issues: #41, #42 (both stay open after merge — fix awaits log evidence)
- `ALIGNMENT.md` Rule 2 invoked
- Historical lesson: PR #40 (concurrency fix) opened these as forensic candidates with the explicit "do not patch speculatively" gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)