### PR TITLE
fix(cli): set DISABLE_AUTOUPDATER=1 in manual restart fallback

### DIFF
--- a/ocp
+++ b/ocp
@@ -604,7 +604,7 @@ cmd_restart() {
       self_r="${BASH_SOURCE[0]}"
       while [[ -L "$self_r" ]]; do self_r="$(readlink "$self_r")"; done
       script_dir="$(cd "$(dirname "$self_r")" && pwd)"
-      nohup node "$script_dir/server.mjs" >> "$HOME/.ocp/logs/proxy.log" 2>&1 &
+      DISABLE_AUTOUPDATER=1 nohup node "$script_dir/server.mjs" >> "$HOME/.ocp/logs/proxy.log" 2>&1 &
     fi
     sleep 3
     if curl -sf --max-time 5 "$PROXY/health" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

One-line fix to `ocp` CLI: prepend `DISABLE_AUTOUPDATER=1` when the manual restart fallback launches `server.mjs` via nohup. Stops claude-code's in-binary auto-updater from firing after each successful claude invocation, which is the root cause of the recurring 8/8 concurrency lockup (refs #37, #40 forensics).

## Why

claude-code's native binary contains an auto-updater. After each successful run it checks upstream; on partial install.cjs failure (network blip, race condition), it leaves `bin/claude.exe` as an ASCII shim. Next OCP request → `spawnSync ENOEXEC` → slot stuck → eventually 8/8 lockup.

Setting `DISABLE_AUTOUPDATER=1` at the launch site stops the trigger. Verified: 24h+ stable on the maintainer's Mac after applying full multi-layer fix on 2026-04-30 (claude.exe mtime unchanged, OCP uptime 22h54m, 0 errors over real call traffic).

## Scope

- Touches `ocp` (CLI bash script) only — **no `server.mjs` change**, so ALIGNMENT.md / `cli.js` citation requirement is not in scope.
- Covers the manual nohup fallback path only. Users with launchctl plists or systemd units need the env in their plist/unit file too.
- Authoritative location for the env is `~/.claude/settings.json` env key (per Anthropic docs). The plist/CLI/shell paths are belt-and-suspenders. `DISABLE_AUTOUPDATER` alone is also known to be unreliable per anthropics/claude-code#11263 / #14985 — strongly consider also setting `DISABLE_UPDATES=1` (blocks manual `claude update` too).

## Test plan

- [x] Verified on maintainer's Mac mini: 24h stable post-fix
- [x] No `server.mjs` change → ALIGNMENT.md CI blacklist unaffected
- [ ] Reviewer (Iron Rule 10): for a 1-line bash env-var prefix this is borderline; please verify the diff is exactly what the description claims

## Iron Rule check

- 0 (PM mode): 1 line, no design decision — direct edit
- 5.5 (release kit): no API/feature change → no version bump; README Troubleshooting could mention but optional
- 10 (independent reviewer): not self-merged; needs your :+1:
- 11 (IDR): one PR, one layer (operational tooling, not server runtime)
- 12 (prior-art search): WebSearched docs + GitHub issues before authoring; see commit body