### PR TITLE
docs(governance): correct CLAUDE.md + AGENTS.md to reflect actual alignment.yml blacklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Runtime: Node.js (ESM, `.mjs` throughout). No build step. No bundler. `server.mj
 ## Project-specific constraints
 
 - **`ALIGNMENT.md` is binding.** Any PR touching `server.mjs` must cite `cli.js:NNNN` (or `cli.js vE4 <functionName>`) in the commit body and PR description. See `CLAUDE.md` § "Hard requirements for `server.mjs` changes" and ADR 0002.
-- **Alignment CI is not suppressible.** The `alignment.yml` workflow greps `server.mjs` for known-hallucinated tokens (including `api/oauth/usage`, `api/usage`). Adding to the blacklist is fine; removing entries requires an `ALIGNMENT.md` amendment PR.
+- **Alignment CI is not suppressible.** The `alignment.yml` workflow greps `server.mjs` for known-hallucinated tokens (currently blocking `api.anthropic.com/api/oauth/usage`). Adding new tokens is done via PR amendment to `alignment.yml`; removing entries requires an `ALIGNMENT.md` amendment PR.
 - **No self-approval.** Implementation author cannot merge their own PR (Iron Rule 10). A fresh-context reviewer must open `cli.js` at the cited lines and confirm in the review comment.
 - **`models.json` is the only place to add/edit models.** Do not touch `MODEL_MAP` or `MODELS` arrays directly in `server.mjs` or `setup.mjs`. See ADR 0003.
 - **OpenClaw boundary.** `scripts/sync-openclaw.mjs` only writes `models.providers["claude-local"].models` and `agents.defaults.models["claude-local/*"]` in `~/.openclaw/openclaw.json`. Do not expand scope. See ADR 0004.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 Every PR that modifies `server.mjs` must satisfy all three of the following. A PR missing any one of them is blocked from merge.
 
 1. **`cli.js` citation.** The commit message and PR body declare the corresponding `cli.js` function name and line number range, using the format `cli.js:NNNN` or `cli.js vE4 <functionName>`. If `cli.js` does not perform the operation, the PR must state this explicitly and justify scope under `ALIGNMENT.md` Rule 2 (in practice, this almost always means the PR should be closed).
-2. **CI blacklist pass.** The `alignment.yml` workflow must pass. The workflow greps `server.mjs` for known-hallucinated tokens (including `api/oauth/usage` and `api/usage`) and fails the build on any hit. Do not suppress the workflow. Do not add allowlist entries without an amendment PR to `ALIGNMENT.md`.
+2. **CI blacklist pass.** The `alignment.yml` workflow must pass. The workflow greps `server.mjs` for known-hallucinated tokens (currently blocking `api.anthropic.com/api/oauth/usage`) and fails the build on any hit. New tokens are added via PR amendment to `alignment.yml`; removing entries requires an `ALIGNMENT.md` amendment PR. Do not suppress the workflow.
 3. **Independent reviewer (Iron Rule 10).** The implementation author may not self-approve. A separate reviewer — human or a subagent spawned with a fresh context — must read the diff, verify the `cli.js` citation by opening `cli.js` at the cited lines, and explicitly approve. A review comment that does not confirm the `cli.js` citation was checked is not a valid approval.
 
 ---


### PR DESCRIPTION
## Summary

Doc-only fix: both `CLAUDE.md` (line 25) and `AGENTS.md` (line 46) claimed the `alignment.yml` blacklist included **two** hallucinated tokens (`api/oauth/usage` and `api/usage`). The actual workflow has **one** token: `api.anthropic.com/api/oauth/usage`.

## Evidence

```bash
$ grep -A2 'BLACKLIST=(' .github/workflows/alignment.yml
          BLACKLIST=(
            "api.anthropic.com/api/oauth/usage"
          )
```

Compared with the previous doc claim:

> "...known-hallucinated tokens (including `api/oauth/usage` and `api/usage`)..."

The doc overstated coverage. CI was always reality; the docs drifted.

## Why no `alignment.yml` change

Adding `api/usage` (or any other token) to the BLACKLIST is a constitutional expansion that requires an `ALIGNMENT.md` amendment PR per ALIGNMENT.md Amendment Procedure. That's a separate decision.

This PR is **doc-truth only** — bring the docs in line with what CI actually enforces today. If `api/usage` should be added, open a follow-up.

## Test plan

- [x] CLAUDE.md and AGENTS.md describe the single-token blacklist accurately
- [x] No change to `alignment.yml` (constitutional file)
- [ ] Reviewer confirms by re-reading `.github/workflows/alignment.yml` BLACKLIST array