### PR TITLE
chore(naming): rename package + code refs from openclaw-claude-proxy to OCP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openclaw-claude-proxy",
+  "name": "open-claude-proxy",
   "version": "3.12.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",

--- a/setup.mjs
+++ b/setup.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * openclaw-claude-proxy setup
+ * OCP (Open Claude Proxy) setup
  *
  * Automatically configures OpenClaw to use Claude CLI as a model provider.
  * Run: node setup.mjs [--port 3456] [--default-model opus|sonnet|haiku] [--dry-run]
@@ -217,7 +217,7 @@ const logDir = join(OPENCLAW_DIR, "logs");
 if (!existsSync(logDir)) mkdirSync(logDir, { recursive: true });
 
 const startSh = `#!/bin/bash
-# Start openclaw-claude-proxy if not already running
+# Start OCP (Open Claude Proxy) if not already running
 PORT=\${CLAUDE_PROXY_PORT:-${PORT}}
 if ! lsof -i :\$PORT -sTCP:LISTEN &>/dev/null; then
   unset CLAUDECODE

--- a/uninstall.mjs
+++ b/uninstall.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * openclaw-claude-proxy uninstaller
+ * OCP (Open Claude Proxy) uninstaller
  *
  * Stops and removes the launchd (macOS) or systemd (Linux) auto-start entry.
  * Handles both legacy (ai.openclaw.proxy / openclaw-proxy) and current


### PR DESCRIPTION
## Summary

Normalize project name from the legacy `openclaw-claude-proxy` to the current branding `OCP (Open Claude Proxy)`.

### npm name

`ocp` is squatted (deprecated `node-ocp` v0.0.1, see \`npm view ocp\`). Falling back to `open-claude-proxy`, which is verified available (\`npm view open-claude-proxy\` → 404).

### Changes

| File | Change |
|---|---|
| `package.json` | `"name"`: `openclaw-claude-proxy` → `open-claude-proxy` |
| `setup.mjs` | header JSDoc + start.sh banner string |
| `uninstall.mjs` | header JSDoc |

`bin` map kept **both** `openclaw-claude-proxy` and `ocp` entries — existing installs that reference the old binary name continue to work.

### Intentionally NOT changed

- **`server.mjs` startup banner (line 1628)** — `console.log('openclaw-claude-proxy v...')`. Editing `server.mjs` requires a `cli.js:NNNN` citation per ALIGNMENT.md Rule 1. A cosmetic log-string rename has no `cli.js` correspondence, so this is deferred. Could be picked up in a separate PR with an ALIGNMENT.md scope justification.
- **`bin` aliases** — kept both names for back-compat.

## Evidence

```bash
$ npm view ocp
ocp@0.0.1 | DEPRECATED — node-ocp squatter

$ npm view open-claude-proxy
npm error 404 Not Found  # available

$ grep -n openclaw-claude-proxy server.mjs setup.mjs uninstall.mjs keys.mjs
server.mjs:3   * openclaw-claude-proxy — OpenAI-compatible proxy for Claude CLI
server.mjs:1628  console.log(`openclaw-claude-proxy v${VERSION} ...`);  # left alone (ALIGNMENT.md Rule 1)
```

## Test plan

- [x] `npm view open-claude-proxy` confirms availability
- [x] `bin` map retains `openclaw-claude-proxy` for back-compat
- [ ] Reviewer: confirm no installer (\`setup.mjs\`) still hardcodes the old name in a runtime path
- [ ] Reviewer: confirm `server.mjs` is intentionally left alone (per ALIGNMENT.md)