### PR TITLE
test: wire test-features.mjs to npm test + add minimal CI smoke workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-features:
+    name: test-features.mjs (smoke)
+    runs-on: ubuntu-latest
+
+    # `test-features.mjs` is self-contained — it runs assertions against the
+    # `keys.mjs` DB layer using a throwaway test database. It does NOT need a
+    # live claude CLI or a running OCP server. So this job runs as a hard
+    # check on every push / PR.
+    #
+    # If a future expansion of the suite adds tests that DO require a live
+    # claude CLI or a running OCP server, mark those steps `continue-on-error:
+    # true` (or split them into a separate job) — CI must not be flaky on
+    # things outside the contributor's machine.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          # Node 24 ships `node:sqlite` as stable. The test imports keys.mjs,
+          # which uses `import { DatabaseSync } from "node:sqlite"`.
+          # Node 22 also works with `--experimental-sqlite`, but we run on 24
+          # to keep the CI step simple and to match what released OCP runs on.
+          node-version: '24'
+
+      # OCP has zero runtime npm dependencies (package-lock.json shows only
+      # the project's own package and zero external entries). No install
+      # step needed — `node:*` modules are built into Node 24.
+
+      - name: Run test-features.mjs
+        run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Runtime: Node.js (ESM, `.mjs` throughout). No build step. No bundler. `server.mj
 - `models.json` as the single source of truth for model metadata
 - GitHub Actions for CI (`alignment.yml`, `release.yml`)
 - `gh` CLI assumed for PR creation and release automation
-- No TypeScript. No test framework beyond `test-features.mjs`. Keep dependencies minimal.
+- No TypeScript. No test framework beyond `test-features.mjs` (run via `npm test`; CI workflow `.github/workflows/test.yml`). Keep dependencies minimal.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "node server.mjs",
-    "setup": "node setup.mjs"
+    "setup": "node setup.mjs",
+    "test": "node test-features.mjs"
   },
   "keywords": [
     "openclaw",


### PR DESCRIPTION
## Summary

`test-features.mjs` shipped at v3.8.0 (per the keys.mjs quota+cache work) and is referenced in `AGENTS.md` as the project's only test artifact. Until now nothing actually ran it — no `npm test` script, no CI step. This wires it up.

## Changes

| File | Change |
|---|---|
| `package.json` | adds `"test": "node test-features.mjs"` |
| `.github/workflows/test.yml` | new minimal CI: Node 24, runs `npm test` on push to main + every PR |
| `AGENTS.md` | notes the `npm test` + workflow wiring |

## Hard check, not soft

`test-features.mjs` is self-contained — it imports `keys.mjs` and runs SQLite-backed assertions against a throwaway test DB at `~/.ocp/ocp-test.db`. It does **not** need:

- a live claude CLI
- a running OCP server
- any network access

So CI runs it as a real check; no `continue-on-error` needed. The workflow comment documents the rule for any future test that DOES require a live runtime.

## Node version pinning

`keys.mjs` uses `import { DatabaseSync } from "node:sqlite"`. That module was experimental in Node 22 (needs `--experimental-sqlite`) and stable in Node 23+. CI uses Node 24 (current LTS as of 2026-04-29) for simplicity.

`package.json` engines remain `>=18`, but in practice the SQLite-backed multi-mode auth requires Node 23+. Bumping engines is out of scope for this PR — call out in a follow-up if the discrepancy matters.

## Local verification

```
$ npm test
[... 24 assertions ...]
=== Results: 24 passed, 0 failed ===
$ echo $?
0
```

## Test plan

- [x] Local `npm test` exits 0 with all 24 assertions passing
- [x] `process.exit(failed > 0 ? 1 : 0)` present at end of test-features.mjs (CI will redden on failure)
- [ ] Reviewer: confirm CI run on this PR's `chore/wire-test-features` branch passes
- [ ] Reviewer: confirm Node 24 is acceptable (vs Node 22 with `--experimental-sqlite`)