### PR TITLE
chore(deps): bump engines to >=22.5 to match node:sqlite usage in keys.mjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ OCP has two roles: **Server** (runs the proxy, needs Claude CLI) and **Client** 
 > **Recommended:** Install OCP on a device that stays powered on — Mac mini, NAS, Raspberry Pi, or a desktop that doesn't sleep. This ensures all clients always have access.
 
 **Prerequisites:**
-- Node.js 18+
+- Node.js 22.5+ (Node 23+ recommended — `node:sqlite` is fully stable without flags from 23.0; on 22.5–22.x it works behind `--experimental-sqlite`)
 - [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) installed and authenticated (`claude auth login`)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=22.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Audit side-finding: `package.json` declared `"engines": { "node": ">=18" }` but `keys.mjs:3` imports `node:sqlite`, which does not exist in Node 18-22.4.

**Decision**: Bump `engines.node` to `>=22.5`, document the flag distinction in README.

## Evidence

- `keys.mjs:3` — `import { DatabaseSync } from "node:sqlite";` (only file using it; verified via grep across `keys.mjs server.mjs setup.mjs`).
- `node:sqlite` availability per Node release notes:
  - **22.5.0**: available behind `--experimental-sqlite` flag
  - **23.0.0+**: available without any flag (stable)
- Conservative engines value `>=22.5` covers both flag-on and flagless paths; users on 22.x will at least get an immediate engine-mismatch warning rather than an opaque module-not-found at runtime.

## Changes

1. **package.json**: `engines.node ">=18"` → `">=22.5"` (1 line).
2. **README.md** § Server Setup → Prerequisites: `Node.js 18+` → `Node.js 22.5+ (Node 23+ recommended — node:sqlite is fully stable without flags from 23.0; on 22.5–22.x it works behind --experimental-sqlite)` (1 bullet rewritten).

## Test plan

- [x] `keys.mjs:3` confirmed as the sole `node:sqlite` import (grep)
- [x] Local `node --version` = v25.8.0 (≥22.5); `npm install` exit 0, no engine warning
- [x] README prerequisite list updated with flag distinction
- [ ] CI alignment.yml passes

## Refs

Audit side-finding 2 of 4 (cleanup batch).