### PR TITLE
chore(ci): add gitleaks workflow to scan PRs and pushes to main

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,32 @@
+name: gitleaks
+
+# Secret scanning gate. Runs on every PR (any branch) and every push to main.
+# Configuration is read from the repo-root `.gitleaks.toml` automatically.
+# Hard-fails the build on any detected leak — public repo, no tolerance.
+#
+# To extend the allowlist (e.g. a new known-safe placeholder), edit
+# `.gitleaks.toml`. Do not add `continue-on-error` here without an explicit
+# governance decision.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: gitleaks scan (hard fail)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Audit side-finding: `.gitleaks.toml` exists at repo root with project-specific allowlist entries (public OAuth client ID, README placeholders, an old plan doc), but no workflow invoked it. The config was orphan — real secret-scanning protection only happened when someone ran gitleaks locally, never gating merges.

This PR wires it into CI.

## Workflow design

- **Triggers**: every `pull_request` (any branch), every `push` to `main`.
- **Action**: `gitleaks/gitleaks-action@v2` (officially maintained, auto-detects `.gitleaks.toml` at repo root).
- **Hard fail** on any leak. No `continue-on-error`. Public repo, no tolerance.
- **Permissions**: `contents: read` (minimum needed).
- **`fetch-depth: 0`**: scan full history.

## Why hard-fail makes sense here

- Public repo — once a secret is pushed, it's leaked even if force-pushed away.
- The existing `.gitleaks.toml` already encodes legitimate safe-string allowlist entries, so false positives are mitigated.
- Soft-fail on a security gate teaches reviewers to ignore it. Hard-fail forces a decision: fix the leak, or amend the allowlist with explicit reasoning.

## Test plan

- [x] `.gitleaks.toml` exists at repo root and is non-empty (verified: contains `title`, `[allowlist]`, regex + path entries).
- [x] No third-party dependency added (action is hosted by `gitleaks` org, pinned to `@v2` major).
- [ ] Workflow runs on this PR itself — must pass green before merge (audit confirmed no live secrets in tree).
- [ ] After merge: `gh workflow list -R dtzp555-max/ocp` shows `gitleaks` registered.

## Refs

Audit side-finding 4 of 4 (cleanup batch).