### PR TITLE
chore(release): v3.13.0 — cache layer hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v3.13.0 — 2026-05-07
+
+### Features (cache layer hardening)
+
+- **Per-key cache isolation** (D1) — the cache key now includes the API key id, so distinct keys never share cache entries. Anonymous/unauthenticated callers share one `anon` pool. Hash format upgraded to `v2`; legacy v1-format rows orphan and are reaped by the existing TTL cleanup interval (no migration script).
+- **`cache_control` bypass** (D2) — when a request carries an Anthropic `cache_control` annotation (top-level or nested in a content array), OCP skips its own cache entirely. The caller is using Anthropic-side prompt caching deliberately, and OCP must not interfere. A `cache_skipped{reason: cache_control_present}` log line is emitted on bypass.
+- **Chunked stream replay** (D3) — when a streaming request hits the cache, the cached content is now emitted as multiple SSE chunks (80 codepoints/chunk, codepoint-safe via `Array.from()`) instead of a single large delta. Multibyte characters (CJK / emoji) stay intact.
+- **Singleflight stampede protection** (D4) — concurrent identical cache-miss requests now share one upstream `cli.js` spawn instead of spawning N processes. Followers receive byte-identical responses to what the leader returns. All-or-nothing failure semantics: if the leader errors, all followers receive the same error. Streaming-path singleflight is explicitly out of scope (TODO left for follow-up).
+
+### Behavior changes
+
+- `/cache/stats` response now includes additive fields `inflight` and `requesters` (current in-flight singleflight entries and total waiting callers). Existing fields `entries`, `totalHits`, `sizeBytes` are preserved unchanged.
+
+### Governance
+
+- New ADR [`docs/adr/0005-no-multi-provider.md`](docs/adr/0005-no-multi-provider.md): OCP stays single-provider (Anthropic via `cli.js` spawn). Multi-provider gateway refactor explicitly out of scope; cache improvements are explicitly in scope.
+- Design spec for this release: [`docs/superpowers/specs/2026-05-07-cache-upgrade-design.md`](docs/superpowers/specs/2026-05-07-cache-upgrade-design.md).
+
+### No new env vars / no public API surface change
+
+This release adds no new env vars or endpoints. All four improvements are internal correctness/concurrency upgrades to the existing `CLAUDE_CACHE_TTL`-gated cache layer. No client-observable wire shape change.
+
 ## v3.12.0 — 2026-04-25
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -472,17 +472,20 @@ ocp settings cacheTTL 300000
 ```
 
 **How it works:**
-- Cache key = SHA-256 of `model` + `messages` + `temperature` + `max_tokens` + `top_p`
+- Cache key = SHA-256 of `v2|<keyId or "anon">|model + messages + temperature + max_tokens + top_p`
+- **Per-key isolation** — different API keys never share cache entries; anonymous callers share one `anon` pool
 - Cache hits return instantly — no Claude CLI process spawned
-- Works for both streaming and non-streaming requests
+- **Streaming hits** are replayed as multiple SSE chunks (80 codepoints each), not one large delta — incremental render preserved
+- **`cache_control` bypass** — if a request carries an Anthropic `cache_control` annotation (top-level or nested in `content[]`), OCP skips its own cache entirely so it doesn't interfere with Anthropic-side prompt caching
+- **Singleflight stampede protection** — concurrent identical cache-miss requests share one upstream `cli.js` spawn; followers receive byte-identical responses to the leader's call. Non-streaming path only (streaming-path singleflight is a known TODO)
 - Multi-turn conversations (with `session_id`) are never cached
 - Expired entries are cleaned up automatically every 10 minutes
 
 **Management:**
 ```bash
-# View cache stats
+# View cache stats (now includes singleflight in-flight counts)
 curl http://127.0.0.1:3456/cache/stats
-# → { "entries": 42, "totalHits": 156, "sizeBytes": 284000 }
+# → { "entries": 42, "totalHits": 156, "sizeBytes": 284000, "inflight": 0, "requesters": 0 }
 
 # Clear all cached responses
 curl -X DELETE http://127.0.0.1:3456/cache
@@ -492,6 +495,8 @@ ocp settings cacheTTL 0
 ```
 
 Cache is **disabled by default** (`CLAUDE_CACHE_TTL=0`). All data is stored locally in `~/.ocp/ocp.db`.
+
+**Hash format upgrade in v3.13.0:** legacy `v1` cache rows from earlier versions don't match new `v2`-format lookups; they orphan and are reaped by the TTL cleanup interval within one window. No migration script required.
 
 ## How It Works
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release prep for v3.13.0. Bumps version, updates CHANGELOG, and updates the README §Response Cache section to document the four cache-layer improvements that landed in #65 and #66.

## What's in v3.13.0

- **D1** — per-key cache isolation (PR #65)
- **D2** — `cache_control` bypass (PR #65)
- **D3** — chunked stream replay (PR #65)
- **D4** — singleflight stampede protection on non-streaming path (PR #66)
- ADR 0005 (no multi-provider) committed
- Spec at `docs/superpowers/specs/2026-05-07-cache-upgrade-design.md`

## Claude Code Alignment Evidence (REQUIRED)

- [x] **Corresponding `cli.js` reference.** N/A — release-prep PR. No code changes; only `package.json`, `CHANGELOG.md`, `README.md`. `server.mjs` is not modified by this PR.
- [x] **If `cli.js` does not perform this operation**: N/A — no behavior change in this PR. The four cache-layer features it documents have already landed in #65 and #66; both of those PRs stated explicitly that `cli.js` does not perform proxy-layer response caching / stampede protection, and were justified under ALIGNMENT.md Rule 2's value-add carve-out. **No client-observable wire shape change** in this release.
- [x] **Commit message citations.** Verified — no "Claude Code uses X" / "cli.js uses X" assertions in this commit.

## Type of change

- [x] Documentation / governance

## Reviewer checklist

- [x] **End-to-end smoke verification of the four features** (run on temp instance with launchctl OCP unloaded, against the merged main code):
  - **D1** — 2 distinct keys, identical prompt → 2 distinct cache hashes; same key 2nd call → cache hit (50ms)
  - **D2** — request with `cache_control` annotation → `cache_skipped{reason: cache_control_present}` log; cache count unchanged
  - **D3** — streaming cache hit → 6 SSE `data:` lines for a 198-char cached content (1 role + 3 content @ 80cp + 1 stop + 1 DONE)
  - **D4** — 5 concurrent identical requests with same key → **1 `claude_spawned` event**, 1 cache entry, byte-identical content across all 5 responses, all 5 responses arrive within 0.0005s of each other (waiting on the same leader)
- [x] CI on #65 + #66: 4/4 checks pass (commit citation, gitleaks, server.mjs blacklist, test-features.mjs smoke)
- [x] 43/43 unit tests pass on the merged main (24 existing + 12 PR-A + 7 PR-B)
- [x] Independent fresh-context reviewer (opus subagent) approved both #65 and #66 with no required changes

## Release artifacts

- `package.json`: `3.12.0` → `3.13.0`
- `CHANGELOG.md`: v3.13.0 entry added
- `README.md`: §Response Cache section updated with v3.13.0 behavior (per-key, bypass, chunked replay, singleflight, hash format upgrade note)

## Tag push

After merge, the maintainer will run:
```bash
git checkout main && git pull
git tag -a v3.13.0 -m "v3.13.0"
git push origin v3.13.0
```
which triggers `.github/workflows/release.yml` to auto-create the GitHub Release.

## Related

- Closes the cache hardening initiative driven by [ADR 0005](docs/adr/0005-no-multi-provider.md) decision §3
- Sibling PRs: #65, #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)