### PR TITLE
docs(funding): add Buy Me a Coffee link + GitHub FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# GitHub recognizes this file and shows a "Sponsor" button on the repo page.
+# Add other platforms here as they get set up. Empty / commented-out entries
+# are skipped silently.
+
+buy_me_a_coffee: dtzp555
+
+# github: [dtzp555-max]   # uncomment after GitHub Sponsors enrollment is approved
+# ko_fi: dtzp555
+# custom: ["https://example.com/donate"]

--- a/README.md
+++ b/README.md
@@ -706,6 +706,18 @@ OCP runs under a small set of binding documents so contributions stay aligned wi
 
 If you want to contribute: read `ALIGNMENT.md` first, search `cli.js` for the operation you're proposing, and cite the line number in your PR.
 
+## Support OCP
+
+OCP is and will always remain **free and open source**. I built it because I needed it myself, and I plan to keep maintaining it as long as the Claude Code ecosystem keeps evolving.
+
+Behind the version numbers are hundreds of hours of work that don't show up in commits: debugging across Mac / Windows / Linux machines, validating against half a dozen IDEs (Claude Code, Cursor, Cline, OpenCode, Aider, Continue.dev, OpenClaw), tracking down `cli.js` drift, OAuth refresh edge cases, SSE streaming quirks, concurrency leaks, and the occasional incident that turns into a multi-day investigation (the [2026-04-11 alignment drift](./docs/adr/0002-alignment-constitution.md), the [v3.11.1 concurrency leak](./CHANGELOG.md), the v3.12 SSE replay regression).
+
+If OCP lets you keep your Claude Pro / Max subscription powering every IDE on every machine — saving the per-token API cost you'd otherwise pay — and you'd like to chip in toward the next debugging session:
+
+- ☕ **[Buy me a coffee](https://buymeacoffee.com/dtzp555)**
+
+No paid tiers. No premium features. No "Pro" version. Donations directly fund the time it takes to keep this project saving the community money.
+
 ## License
 
 MIT — see [`LICENSE`](LICENSE).


### PR DESCRIPTION
## Summary

Adds a single ☕ donation link to the README and a `.github/FUNDING.yml` file so GitHub auto-renders the "Sponsor" button on the repo page.

The accompanying README §Support OCP section makes three things explicit:
1. OCP **stays free and open source forever** (no paid tiers, no premium features)
2. The maintainer commits to ongoing maintenance as the Claude Code ecosystem evolves
3. Donations fund maintenance time only — they do not buy access to anything users can't already get

## Claude Code Alignment Evidence (REQUIRED)

- [x] **Corresponding `cli.js` reference.** N/A — docs-only PR, no `server.mjs` change.
- [x] **If `cli.js` does not perform this operation**: N/A — README and `.github/FUNDING.yml` are not network-facing surface.
- [x] **Commit message citations.** Verified — no `cli.js uses X` assertions in this PR's commits.

## Type of change

- [x] Documentation / governance

## What's in the diff

- `.github/FUNDING.yml` — new file. Currently enables `buy_me_a_coffee: dtzp555`. GitHub Sponsors and Ko-fi are commented-out placeholders that can be uncommented later when those accounts are set up.
- `README.md` — adds a new `## Support OCP` section just before `## License`, with the explicit free-forever pledge and a single ☕ link. No other content changed.

## Reviewer checklist

- [x] No code changes; CI alignment guardrail trivially passes (server.mjs untouched)
- [x] FUNDING.yml syntax is GitHub-recognized format
- [x] README section is at the bottom (less aggressive than top placement) and explicitly disclaims paid tiers to keep the OSS posture unambiguous

## Related

- ADR 0005 (no multi-provider, OCP stays a personal power tool + OSS) — this PR reinforces that posture by setting up OSS-aligned funding rather than commercialization
- No version bump; docs-only changes don't trigger a release per `release_kit` overlay