### PR TITLE
fix(setup): remove duplicate server spawn; verify health post-install

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -264,13 +264,6 @@ console.log(`
 ╚══════════════════════════════════════════════════════════════╝
 `);
 
-// ── Step 6: Optionally start ────────────────────────────────────────────
-if (!SKIP_START && !DRY_RUN) {
-  try {
-    execSync(`bash "${startPath}"`, { stdio: "inherit" });
-  } catch { /* ignore */ }
-}
-
 // ── Step 7: Install auto-start on boot ──────────────────────────────────
 if (!DRY_RUN) {
   console.log("\n🔄 Installing auto-start on login...\n");
@@ -405,4 +398,52 @@ WantedBy=default.target
   }
 
   console.log("\n✅ Auto-start installed — proxy will start automatically on login\n");
+
+  // ── Step 8: Post-install health verification ───────────────────────────
+  if (!SKIP_START) {
+    console.log("⏳ Waiting for server to bind...\n");
+    await new Promise(r => setTimeout(r, 3000));
+
+    const healthUrl = `http://127.0.0.1:${PORT}/health`;
+    let verified = false;
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 5000);
+      const res = await fetch(healthUrl, { signal: controller.signal });
+      clearTimeout(timer);
+
+      if (res.ok) {
+        const body = await res.json().catch(() => ({}));
+        console.log(`  ✓ Health check passed (${healthUrl})`);
+        console.log(`    version:  ${body.version ?? "unknown"}`);
+        console.log(`    authMode: ${body.authMode ?? "unknown"}`);
+
+        // Verify bind socket
+        try {
+          const bindCheck = process.platform === "linux"
+            ? execSync(`ss -tlnp 2>/dev/null | grep ':${PORT}'`, { encoding: "utf-8" }).trim()
+            : execSync(`lsof -nP -iTCP:${PORT} -sTCP:LISTEN 2>/dev/null`, { encoding: "utf-8" }).trim();
+          if (bindCheck) {
+            console.log(`    bind:     ${bindCheck.split("\n")[0]}`);
+          }
+        } catch { /* bind check is best-effort */ }
+
+        verified = true;
+      } else {
+        warn(`Health check returned HTTP ${res.status} — service may not have started cleanly`);
+      }
+    } catch (e) {
+      const isTimeout = e.name === "AbortError" || (e.cause && e.cause.code === "UND_ERR_CONNECT_TIMEOUT");
+      warn(`Health check failed: ${isTimeout ? "timeout (5s)" : e.message}`);
+    }
+
+    if (!verified) {
+      const logHint = process.platform === "linux"
+        ? "journalctl --user -u ocp-proxy -n 50"
+        : `tail -n 100 ~/.ocp/logs/proxy.log`;
+      console.error(`\n  ✗ Server did not respond on port ${PORT} within 5 seconds.`);
+      console.error(`    Check service logs:\n      ${logHint}\n`);
+      process.exit(1);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Deleted the old Step 6 (`execSync('bash "${startPath}"')`) that spawned `server.mjs` via `start.sh` **before** the systemd/launchd service was installed. This orphan spawn carried no `CLAUDE_BIND` / `CLAUDE_AUTH_MODE` env vars, so it always started with `bind=127.0.0.1` and `authMode=none` regardless of CLI flags, then blocked the port before Step 7's service could bind.
- Added Step 8: a post-install health verification that waits 3 s then GETs `/health` (5 s timeout). Prints `version`, `authMode`, and bind socket on success; prints service-log hint and exits 1 on failure.
- `start.sh` is unchanged — still available for manual non-systemd launches. setup.mjs no longer calls it.

## Live evidence — Pi231 (RPi4 / Debian Bookworm, 2026-05-08)

```
$ node setup.mjs --bind 0.0.0.0 --auth-mode multi
... (exit 0)

$ curl -s http://localhost:3456/health | jq '{authMode, bind}'
{ "authMode": "none", "bind": "127.0.0.1" }

$ ps -ef | grep server.mjs
501 379413  1  nohup node server.mjs   ← orphan from Step 6, wrong config
501 379830  1  node server.mjs         ← systemd, EADDRINUSE, 99% CPU looping
```

Identified during PR #71 dogfood testing.

## Root cause (two-step conflict)

**Step 6** called `execSync('bash "${startPath}"')` → `start.sh` did `nohup node server.mjs &` with no env vars exported → default bind + authMode.

**Step 7** wrote systemd unit with correct `CLAUDE_BIND` + `CLAUDE_AUTH_MODE`, then ran `systemctl --user start ocp-proxy` → EADDRINUSE (Step 6 already owned the port) → silent restart loop.

`setup.mjs` exited 0 because Step 6's spawn "succeeded" — the wrong server was running.

## Fix description

1. **Deleted Step 6 entirely.** The service installed by Step 7 is now the sole authoritative start path.
2. **Added Step 8** (inside `if (!DRY_RUN)`, skipped when `--no-start`):
   - 3 s sleep for bind time
   - `fetch(http://127.0.0.1:${PORT}/health, { signal: AbortController @ 5s })`
   - On 200 OK: logs `version`, `authMode`, bind socket (best-effort `lsof`/`ss`)
   - On failure: prints actionable log-hint (`journalctl` / `tail ~/.ocp/logs/proxy.log`) and `process.exit(1)`

## Test plan

- [x] `--dry-run` exits 0 without touching any files, no spawn (verified locally)
- [x] `--no-start` installs service, skips health check (verified locally via `launchctl`, port free after bootout+cleanup)
- [x] Normal run: exactly ONE `server.mjs` process post-install, parent PID = 1 (launchd), health returns `authMode: none` on port 3478 (verified locally on macOS)
- [x] Port 3478 cleaned up, no zombie processes after test
- [ ] Pi231 / Linux: run with `--bind 0.0.0.0 --auth-mode multi`, verify health check shows correct authMode, exactly one process, no EADDRINUSE

## Notes

- Does not touch `server.mjs`, `README.md`, `ALIGNMENT.md`, `CLAUDE.md`, `models.json`, or `package.json` — constrained to the process-lifecycle layer in `setup.mjs`.
- `start.sh` content unchanged; this PR does not fix the env-var leak inside `start.sh` (separate concern, different PR layer).

Identified during PR #71 dogfood testing on Pi231 (RPi4 / Debian Bookworm).