### PR TITLE
fix(setup): decouple OpenClaw config patch from being mandatory

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -12,7 +12,7 @@
  *   4. Creates start.sh for easy launch
  *   5. Optionally starts the proxy
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, readdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -107,106 +107,112 @@ try {
   warn("Make sure you're logged in: claude login");
 }
 
-// Check openclaw config
-if (!existsSync(CONFIG_PATH)) fail(`OpenClaw config not found at ${CONFIG_PATH}`);
-log(`OpenClaw config: ${CONFIG_PATH}`);
+// Check openclaw config (optional — OCP runs standalone without OpenClaw)
+const OPENCLAW_PRESENT = existsSync(CONFIG_PATH);
+if (OPENCLAW_PRESENT) {
+  log(`OpenClaw config: ${CONFIG_PATH}`);
+} else {
+  warn(`OpenClaw not detected at ${CONFIG_PATH} — skipping OpenClaw integration.`);
+  warn(`To register OCP with OpenClaw later, install OpenClaw and re-run \`node setup.mjs\`,`);
+  warn(`or run \`ocp update\` if OpenClaw is installed afterward.`);
+}
 
 // ── Step 2: Patch openclaw.json ─────────────────────────────────────────
-console.log("\n📝 Configuring OpenClaw...\n");
+if (OPENCLAW_PRESENT) {
+  console.log("\n📝 Configuring OpenClaw...\n");
 
-const config = readJSON(CONFIG_PATH);
+  const config = readJSON(CONFIG_PATH);
 
-// Ensure models.providers exists
-if (!config.models) config.models = {};
-if (!config.models.providers) config.models.providers = {};
+  // Ensure models.providers exists
+  if (!config.models) config.models = {};
+  if (!config.models.providers) config.models.providers = {};
 
-// Add/update claude-local provider
-config.models.providers[PROVIDER_NAME] = {
-  baseUrl: `http://127.0.0.1:${PORT}/v1`,
-  api: "openai-completions",
-  authHeader: false,
-  models: MODELS,
-};
-log(`Provider "${PROVIDER_NAME}" → http://127.0.0.1:${PORT}/v1`);
+  // Add/update claude-local provider
+  config.models.providers[PROVIDER_NAME] = {
+    baseUrl: `http://127.0.0.1:${PORT}/v1`,
+    api: "openai-completions",
+    authHeader: false,
+    models: MODELS,
+  };
+  log(`Provider "${PROVIDER_NAME}" → http://127.0.0.1:${PORT}/v1`);
 
-// Ensure auth profile in config
-if (!config.auth) config.auth = {};
-if (!config.auth.profiles) config.auth.profiles = {};
-config.auth.profiles[`${PROVIDER_NAME}:default`] = {
-  provider: PROVIDER_NAME,
-  mode: "api_key",
-};
-log(`Auth profile "${PROVIDER_NAME}:default" registered`);
+  // Ensure auth profile in config
+  if (!config.auth) config.auth = {};
+  if (!config.auth.profiles) config.auth.profiles = {};
+  config.auth.profiles[`${PROVIDER_NAME}:default`] = {
+    provider: PROVIDER_NAME,
+    mode: "api_key",
+  };
+  log(`Auth profile "${PROVIDER_NAME}:default" registered`);
 
-// Add models to agents.defaults.models
-if (!config.agents) config.agents = {};
-if (!config.agents.defaults) config.agents.defaults = {};
-if (!config.agents.defaults.models) config.agents.defaults.models = {};
-for (const [key, val] of Object.entries(MODEL_ALIASES)) {
-  config.agents.defaults.models[key] = val;
-}
-log(`Model aliases added to agents.defaults.models`);
-
-// Set idleTimeoutSeconds to 0 — critical for Claude tool-use.
-// When Claude calls tools (Bash, Read, etc.), the token stream pauses for 30-120s.
-// OpenClaw's default idleTimeoutSeconds (60s) kills the connection mid-tool-call,
-// causing exit 143 (SIGTERM) and stuck sessions. Setting to 0 disables the idle timer.
-if (!config.agents.defaults.llm) config.agents.defaults.llm = {};
-if (config.agents.defaults.llm.idleTimeoutSeconds === undefined ||
-    config.agents.defaults.llm.idleTimeoutSeconds > 0) {
-  config.agents.defaults.llm.idleTimeoutSeconds = 0;
-  log(`Set agents.defaults.llm.idleTimeoutSeconds = 0 (prevents tool-call timeouts)`);
-} else {
-  log(`idleTimeoutSeconds already configured: ${config.agents.defaults.llm.idleTimeoutSeconds}`);
-}
-
-writeJSON(CONFIG_PATH, config);
-log(`Config saved`);
-
-// ── Step 3: Patch auth-profiles.json ────────────────────────────────────
-console.log("\n🔑 Configuring auth profiles...\n");
-
-// Find all agent auth-profiles.json files
-const agentsDir = join(OPENCLAW_DIR, "agents");
-const agentDirs = existsSync(agentsDir)
-  ? readdirSync(agentsDir).filter((d) => {
-      const ap = join(agentsDir, d, "agent", "auth-profiles.json");
-      return existsSync(ap);
-    })
-  : [];
-
-import { readdirSync } from "node:fs";
-
-for (const agentId of agentDirs) {
-  const apPath = join(agentsDir, agentId, "agent", "auth-profiles.json");
-  try {
-    const ap = readJSON(apPath);
-    if (!ap.profiles) ap.profiles = {};
-
-    // Add claude-local profile if missing
-    if (!ap.profiles[`${PROVIDER_NAME}:default`]) {
-      ap.profiles[`${PROVIDER_NAME}:default`] = {
-        type: "api_key",
-        provider: PROVIDER_NAME,
-        key: "local-proxy-no-auth",
-      };
-    }
-
-    // Add to lastGood if missing
-    if (!ap.lastGood) ap.lastGood = {};
-    if (!ap.lastGood[PROVIDER_NAME]) {
-      ap.lastGood[PROVIDER_NAME] = `${PROVIDER_NAME}:default`;
-    }
-
-    writeJSON(apPath, ap);
-    log(`Agent "${agentId}" auth profile updated`);
-  } catch (e) {
-    warn(`Skipped agent "${agentId}": ${e.message}`);
+  // Add models to agents.defaults.models
+  if (!config.agents) config.agents = {};
+  if (!config.agents.defaults) config.agents.defaults = {};
+  if (!config.agents.defaults.models) config.agents.defaults.models = {};
+  for (const [key, val] of Object.entries(MODEL_ALIASES)) {
+    config.agents.defaults.models[key] = val;
   }
-}
+  log(`Model aliases added to agents.defaults.models`);
 
-if (agentDirs.length === 0) {
-  warn("No agent auth-profiles.json found — you may need to restart the gateway first");
+  // Set idleTimeoutSeconds to 0 — critical for Claude tool-use.
+  // When Claude calls tools (Bash, Read, etc.), the token stream pauses for 30-120s.
+  // OpenClaw's default idleTimeoutSeconds (60s) kills the connection mid-tool-call,
+  // causing exit 143 (SIGTERM) and stuck sessions. Setting to 0 disables the idle timer.
+  if (!config.agents.defaults.llm) config.agents.defaults.llm = {};
+  if (config.agents.defaults.llm.idleTimeoutSeconds === undefined ||
+      config.agents.defaults.llm.idleTimeoutSeconds > 0) {
+    config.agents.defaults.llm.idleTimeoutSeconds = 0;
+    log(`Set agents.defaults.llm.idleTimeoutSeconds = 0 (prevents tool-call timeouts)`);
+  } else {
+    log(`idleTimeoutSeconds already configured: ${config.agents.defaults.llm.idleTimeoutSeconds}`);
+  }
+
+  writeJSON(CONFIG_PATH, config);
+  log(`Config saved`);
+
+  // ── Step 3: Patch auth-profiles.json ────────────────────────────────────
+  console.log("\n🔑 Configuring auth profiles...\n");
+
+  // Find all agent auth-profiles.json files
+  const agentsDir = join(OPENCLAW_DIR, "agents");
+  const agentDirs = existsSync(agentsDir)
+    ? readdirSync(agentsDir).filter((d) => {
+        const ap = join(agentsDir, d, "agent", "auth-profiles.json");
+        return existsSync(ap);
+      })
+    : [];
+
+  for (const agentId of agentDirs) {
+    const apPath = join(agentsDir, agentId, "agent", "auth-profiles.json");
+    try {
+      const ap = readJSON(apPath);
+      if (!ap.profiles) ap.profiles = {};
+
+      // Add claude-local profile if missing
+      if (!ap.profiles[`${PROVIDER_NAME}:default`]) {
+        ap.profiles[`${PROVIDER_NAME}:default`] = {
+          type: "api_key",
+          provider: PROVIDER_NAME,
+          key: "local-proxy-no-auth",
+        };
+      }
+
+      // Add to lastGood if missing
+      if (!ap.lastGood) ap.lastGood = {};
+      if (!ap.lastGood[PROVIDER_NAME]) {
+        ap.lastGood[PROVIDER_NAME] = `${PROVIDER_NAME}:default`;
+      }
+
+      writeJSON(apPath, ap);
+      log(`Agent "${agentId}" auth profile updated`);
+    } catch (e) {
+      warn(`Skipped agent "${agentId}": ${e.message}`);
+    }
+  }
+
+  if (agentDirs.length === 0) {
+    warn("No agent auth-profiles.json found — you may need to restart the gateway first");
+  }
 }
 
 // ── Step 4: Create start.sh ─────────────────────────────────────────────
@@ -238,31 +244,46 @@ if (!DRY_RUN) {
 log(`Launcher: ${startPath}`);
 
 // ── Step 5: Summary ─────────────────────────────────────────────────────
-console.log(`
-╔══════════════════════════════════════════════════════════════╗
-║                  Setup complete!                             ║
-╠══════════════════════════════════════════════════════════════╣
-║                                                              ║
-║  Provider: ${PROVIDER_NAME.padEnd(44)}║
-║  Port:     ${String(PORT).padEnd(44)}║
-║  Models:   ${`see models.json (${MODELS.length} available)`.padEnd(44)}║
-║  Default:  ${DEFAULT_MODEL_ID.padEnd(44)}║
-║                                                              ║
-║  Start proxy:                                                ║
-║    bash ${startPath.replace(HOME, "~").padEnd(50)}║
-║                                                              ║
-║  Or directly:                                                ║
-║    node ${serverPath.replace(HOME, "~").padEnd(49)}║
-║                                                              ║
-║  Set as default model in openclaw.json:                      ║
-║    agents.defaults.model.primary =                           ║
-║      "${PROVIDER_NAME}/${DEFAULT_MODEL_ID}"${" ".repeat(Math.max(0, 30 - PROVIDER_NAME.length - DEFAULT_MODEL_ID.length))}║
-║                                                              ║
-║  Then restart gateway:                                       ║
-║    openclaw gateway restart                                  ║
-║                                                              ║
-╚══════════════════════════════════════════════════════════════╝
-`);
+const banner = [
+  `╔══════════════════════════════════════════════════════════════╗`,
+  `║                  Setup complete!                             ║`,
+  `╠══════════════════════════════════════════════════════════════╣`,
+  `║                                                              ║`,
+  `║  Provider: ${PROVIDER_NAME.padEnd(44)}║`,
+  `║  Port:     ${String(PORT).padEnd(44)}║`,
+  `║  Models:   ${`see models.json (${MODELS.length} available)`.padEnd(44)}║`,
+  `║  Default:  ${DEFAULT_MODEL_ID.padEnd(44)}║`,
+  `║                                                              ║`,
+  `║  Start proxy:                                                ║`,
+  `║    bash ${startPath.replace(HOME, "~").padEnd(50)}║`,
+  `║                                                              ║`,
+  `║  Or directly:                                                ║`,
+  `║    node ${serverPath.replace(HOME, "~").padEnd(49)}║`,
+  `║                                                              ║`,
+];
+if (OPENCLAW_PRESENT) {
+  banner.push(
+    `║  Set as default model in openclaw.json:                      ║`,
+    `║    agents.defaults.model.primary =                           ║`,
+    `║      "${PROVIDER_NAME}/${DEFAULT_MODEL_ID}"${" ".repeat(Math.max(0, 30 - PROVIDER_NAME.length - DEFAULT_MODEL_ID.length))}║`,
+    `║                                                              ║`,
+    `║  Then restart gateway:                                       ║`,
+    `║    openclaw gateway restart                                  ║`,
+    `║                                                              ║`,
+  );
+} else {
+  banner.push(
+    `║  OpenClaw not detected — running in standalone mode.         ║`,
+    `║  Point your IDE (Cline / Cursor / Continue / OpenCode /      ║`,
+    `║  Aider / OpenClaw) at:                                       ║`,
+    `║    http://${BIND_ADDRESS}:${String(PORT)}/v1${" ".repeat(Math.max(0, 47 - BIND_ADDRESS.length - String(PORT).length))}║`,
+    `║                                                              ║`,
+    `║  See README § "Client Setup" for per-IDE instructions.       ║`,
+    `║                                                              ║`,
+  );
+}
+banner.push(`╚══════════════════════════════════════════════════════════════╝`);
+console.log("\n" + banner.join("\n") + "\n");
 
 // ── Step 6: Optionally start ────────────────────────────────────────────
 if (!SKIP_START && !DRY_RUN) {


### PR DESCRIPTION
## Summary

`setup.mjs` hard-failed on a fresh box without OpenClaw installed, contradicting OCP's "standalone OpenAI-compatible proxy" positioning in the README. This PR makes the OpenClaw config patch optional: when `~/.openclaw/openclaw.json` exists, behavior is byte-for-byte identical to current `main`; when it does not, the installer logs a graceful warning, skips the OpenClaw integration, and continues with the rest of the bootstrap (start.sh, launchd plist / systemd unit, summary banner).

Identified during PR #71 dogfood testing on Pi231.

## Dogfood evidence (Pi231)

Pi231 is a fresh ARM box with no OpenClaw installation. Running the README §Server Setup recipe:

```
git clone https://github.com/dtzp555-max/ocp.git
cd ocp
node setup.mjs
```

aborts at `setup.mjs:111`:

```js
if (!existsSync(CONFIG_PATH)) fail(`OpenClaw config not found at ${CONFIG_PATH}`);
```

where `CONFIG_PATH = ~/.openclaw/openclaw.json`. Nothing OCP-related runs — no `start.sh`, no auto-start unit, nothing.

## Root cause

`setup.mjs` was originally written when OCP shipped as an OpenClaw-internal helper. Since the rebrand to standalone OCP (README now lists six supported IDE clients with OpenClaw as just one), the installer was never decoupled. Step 2 (lines 114-164) patches `openclaw.json`; Step 3 (lines 166-210) patches per-agent `auth-profiles.json`. Both depend on the OpenClaw state directory existing.

## Fix

1. **`setup.mjs:111`** changed from `fail(...)` to a graceful skip flag (`OPENCLAW_PRESENT`). When the file exists, log "OpenClaw config found" and continue. When it does not, log a warning that includes pointers to `node setup.mjs` re-run and `ocp update`.
2. **Steps 2 + 3** wrapped in `if (OPENCLAW_PRESENT) { ... }`. When OpenClaw is absent, both patch sections are skipped entirely. When OpenClaw is present, the inner code is identical to current `main` (verified by `shasum` of `~/.openclaw/openclaw.json` before and after a `--dry-run` — UNCHANGED).
3. **Summary banner** made conditional on `OPENCLAW_PRESENT`. OpenClaw-present banner is unchanged; OpenClaw-absent banner replaces the "Set as default model in openclaw.json" instructions with a neutral pointer to README § "Client Setup" and the proxy URL.
4. **Steps 4 (`start.sh`), 6 (auto-start), 7 (launchd/systemd)** are untouched. They run regardless of OpenClaw presence — that's the OCP-standalone surface that always worked.
5. **`readdirSync` import** moved from mid-file (line 178, post-use, ESM-hoisted) to the top-level imports block. Required because `readdirSync` is now called inside an `if` block, and ESM imports must be top-level statements.

## Behavior matrix

| Scenario                         | Before this PR                        | After this PR                                                |
|----------------------------------|---------------------------------------|--------------------------------------------------------------|
| OpenClaw present, fresh install  | OpenClaw patch + start.sh + auto-start | OpenClaw patch + start.sh + auto-start  (**unchanged**)      |
| OpenClaw present, re-run         | Idempotent re-patch                   | Idempotent re-patch                       (**unchanged**)    |
| OpenClaw absent, fresh install   | **`fail()` at line 111 — nothing runs** | Warn, skip OpenClaw patch, proceed with start.sh + auto-start |
| OpenClaw absent, `--dry-run`     | `fail()`                              | Warn + dry-run-style log of what would happen                |
| Mac mini production              | Patches OpenClaw, registers provider  | Patches OpenClaw, registers provider      (**unchanged**)    |

Mac mini production is unaffected — `~/.openclaw/openclaw.json` already exists there, so the OpenClaw-present path is preserved. `ocp update` doesn't invoke `setup.mjs`, so running services are not touched.

## Out of scope (Iron Rule 11)

This PR is the minimum reviewable unit for "OpenClaw dependency boundary in `setup.mjs`":

- `server.mjs` — unchanged. No `cli.js` citation needed because the proxy itself is untouched.
- `README.md`, `ALIGNMENT.md`, `CLAUDE.md` — unchanged.
- `models.json` — unchanged.
- `scripts/sync-openclaw.mjs` — unchanged. That script is invoked by `ocp update` separately and already gates on OpenClaw presence.
- `package.json` version — not bumped per task instructions.
- The duplicate-spawn / health-verify logic at `setup.mjs:268+` — separate `fix/setup-spawn-conflict` PR.

## Test plan

- [x] `node --check setup.mjs` passes (syntax)
- [x] **Path 1 (OpenClaw present, dry-run):** `node setup.mjs --port 3479 --dry-run` produces functionally identical output to current `main`. All 12 agent auth-profiles dry-run-logged. `~/.openclaw/openclaw.json` sha256 UNCHANGED before/after.
- [x] **Path 2 (OpenClaw absent, dry-run):** `OPENCLAW_STATE_DIR=/tmp/no-such-dir-* node setup.mjs --port 3479 --dry-run --no-start` logs the OpenClaw-not-detected warning, skips both patch sections, prints the standalone-mode banner pointing at `http://127.0.0.1:3479/v1`, and exits 0.
- [x] `npm test` — 43/43 pass.
- [ ] Reviewer (fresh context): open `setup.mjs` diff, confirm no `server.mjs` / `models.json` / `sync-openclaw.mjs` touched, confirm OpenClaw-present block is byte-for-byte equivalent to pre-PR logic (only indentation changed).
- [ ] Reviewer: re-run Path 1 dry-run on a machine with OpenClaw installed and confirm `shasum` of `~/.openclaw/openclaw.json` is unchanged after the run.
- [ ] (Post-merge, on Pi231): run `node setup.mjs --port 3479` and confirm full standalone install completes; `curl http://127.0.0.1:3479/v1/models` returns the model list.

## Risk

Low. The OpenClaw-present path is the existing code wrapped in an `if (OPENCLAW_PRESENT)`; the OpenClaw-absent path was previously a hard `fail()`, so there is no production behavior to regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)