### PR TITLE
fix(ocp-cli): replace eval-curl with bash array to preserve JSON body quoting

### DIFF
--- a/ocp
+++ b/ocp
@@ -8,21 +8,18 @@ set -euo pipefail
 
 PROXY="http://127.0.0.1:3456"
 
-# Auth header for multi-key mode: reads from OCP_ADMIN_KEY env or ~/.ocp/admin-key file
-_AUTH_HEADER=""
+# Auth args for multi-key mode: reads from OCP_ADMIN_KEY env or ~/.ocp/admin-key file
+# Using a bash array preserves word boundaries — no eval needed.
+_AUTH_ARGS=()
 if [[ -n "${OCP_ADMIN_KEY:-}" ]]; then
-  _AUTH_HEADER="-H \"Authorization: Bearer $OCP_ADMIN_KEY\""
+  _AUTH_ARGS=(-H "Authorization: Bearer $OCP_ADMIN_KEY")
 elif [[ -f "$HOME/.ocp/admin-key" ]]; then
-  _AUTH_HEADER="-H \"Authorization: Bearer $(cat "$HOME/.ocp/admin-key")\""
+  _AUTH_ARGS=(-H "Authorization: Bearer $(cat "$HOME/.ocp/admin-key")")
 fi
 
 # Wrapper: curl with optional auth
 _curl() {
-  if [[ -n "$_AUTH_HEADER" ]]; then
-    eval curl "$_AUTH_HEADER" "$@"
-  else
-    curl "$@"
-  fi
+  curl "${_AUTH_ARGS[@]}" "$@"
 }
 
 _json() { python3 -m json.tool 2>/dev/null || cat; }


### PR DESCRIPTION
## Summary

- `ocp keys add <name>` (and any `_curl`-based command) silently failed with `Error: proxy unreachable or unauthorized` when `OCP_ADMIN_KEY` was set — the bug was in the `ocp` shell script, not the server.
- Root cause: `eval curl "$_AUTH_HEADER" "$@"` re-tokenizes its arguments according to bash word-splitting, splitting the JSON body `'{"name": "laptop"}'` into two args `'{name:'` and `'laptop}'`, producing a malformed request body.
- Fix: replace the `_AUTH_HEADER` string + `eval` pattern with a bash array `_AUTH_ARGS`; `"${_AUTH_ARGS[@]}"` expands with preserved word boundaries — no `eval` required.

## Bug evidence (bash -x trace before fix)

```
+++ curl -H 'Authorization: Bearer <KEY>' -sf --max-time 5 -X POST http://127.0.0.1:3456/api/keys \
    -H Content-Type: application/json -d '{name:' 'laptop}'
                                                  ^^^^^^^  ^^^^^^^^
                                                  body split across two args — malformed
```

## Root cause

```bash
# OLD — broken
_AUTH_HEADER="-H \"Authorization: Bearer $OCP_ADMIN_KEY\""
_curl() {
  if [[ -n "$_AUTH_HEADER" ]]; then
    eval curl "$_AUTH_HEADER" "$@"   # eval re-tokenizes: space in JSON body splits it
  else
    curl "$@"
  fi
}
```

## Fix (minimum diff, surgical — single file, no version bump)

```bash
# NEW — correct
_AUTH_ARGS=()
if [[ -n "${OCP_ADMIN_KEY:-}" ]]; then
  _AUTH_ARGS=(-H "Authorization: Bearer $OCP_ADMIN_KEY")
elif [[ -f "$HOME/.ocp/admin-key" ]]; then
  _AUTH_ARGS=(-H "Authorization: Bearer $(cat "$HOME/.ocp/admin-key")")
fi

_curl() {
  curl "${_AUTH_ARGS[@]}" "$@"   # array expansion preserves word boundaries
}
```

## Backward compatibility

- `OCP_ADMIN_KEY` env var path: preserved.
- `~/.ocp/admin-key` file fallback path: preserved.
- Empty / no admin key (empty array `_AUTH_ARGS=()`): `"${_AUTH_ARGS[@]}"` expands to nothing; `curl` receives exactly the same args as before.

## Smoke test results (bash -x trace after fix)

```
# With OCP_ADMIN_KEY set:
++ _curl -sf --max-time 5 -X POST http://127.0.0.1:3456/api/keys \
         -H 'Content-Type: application/json' -d '{"name": "testkey-pr-c"}'
++ curl -H 'Authorization: Bearer test-secret-key-abc123' -sf --max-time 5 \
        -X POST http://127.0.0.1:3456/api/keys \
        -H 'Content-Type: application/json' -d '{"name": "testkey-pr-c"}'
#                                                ^^^^^^^^^^^^^^^^^^^^^^^
#                                                JSON body intact — single arg

# Without OCP_ADMIN_KEY (admin-key file fallback):
++ curl -H 'Authorization: Bearer W7SvSEk...' -sf --max-time 5 \
        -X POST http://127.0.0.1:3456/api/keys \
        -H 'Content-Type: application/json' -d '{"name": "testkey-pr-c"}'
#                                                JSON body intact — single arg
```

Tested via `bash -x ~/ocp/ocp keys add testkey-pr-c` (no actual server hit). No stray keys created.

Identified during fresh-state Round 2 testing on MacBook.

---

> **cli.js citation**: This PR modifies only the `ocp` bash CLI wrapper — it does not touch `server.mjs` or any network-facing proxy surface. No `cli.js` citation is required per `CLAUDE.md` § "Hard requirements for server.mjs changes" (the requirement is scoped to `server.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)