### PR TITLE
fix(server): resolve claude binary from nvm/fnm/asdf and PATH fallback

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -30,7 +30,7 @@
 import { createServer } from "node:http";
 import { spawn, execFileSync } from "node:child_process";
 import { randomUUID, timingSafeEqual } from "node:crypto";
-import { readFileSync, accessSync, existsSync, constants } from "node:fs";
+import { readFileSync, readdirSync, accessSync, existsSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
@@ -41,8 +41,48 @@ const _pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
 const modelsConfig = JSON.parse(readFileSync(join(__dirname, "models.json"), "utf8"));
 
 // ── Resolve claude binary ───────────────────────────────────────────────
-// Priority: CLAUDE_BIN env > well-known paths > which lookup
-// Fail-fast if not found — never start with an unresolvable binary.
+// Priority: CLAUDE_BIN env > well-known paths > nvm/fnm/asdf user-local
+// installs > which lookup. Fail-fast if not found — never start with an
+// unresolvable binary.
+function _listVersionDirs(parent) {
+  try { return readdirSync(parent); } catch { return []; }
+}
+function _collectNodeManagerCandidates(home) {
+  if (!home) return [];
+  const out = [];
+
+  // nvm: $HOME/.nvm/versions/node/<version>/bin/claude
+  const nvmRoot = join(home, ".nvm/versions/node");
+  for (const v of _listVersionDirs(nvmRoot)) {
+    out.push(join(nvmRoot, v, "bin/claude"));
+  }
+  // nvm default alias: resolve $HOME/.nvm/aliases/default if it points to a version
+  try {
+    const aliasFile = join(home, ".nvm/aliases/default");
+    const aliasVer = readFileSync(aliasFile, "utf8").trim();
+    if (aliasVer) {
+      const direct = join(nvmRoot, aliasVer, "bin/claude");
+      if (!out.includes(direct)) out.unshift(direct);
+    }
+  } catch {}
+
+  // fnm: $HOME/.fnm/node-versions/<version>/installation/bin/claude
+  const fnmRoot = join(home, ".fnm/node-versions");
+  for (const v of _listVersionDirs(fnmRoot)) {
+    out.push(join(fnmRoot, v, "installation/bin/claude"));
+  }
+
+  // asdf: $HOME/.asdf/installs/nodejs/<version>/bin/claude
+  const asdfRoot = join(home, ".asdf/installs/nodejs");
+  for (const v of _listVersionDirs(asdfRoot)) {
+    out.push(join(asdfRoot, v, "bin/claude"));
+  }
+
+  // npm prefix-relocated: $HOME/.npm-global/bin/claude
+  out.push(join(home, ".npm-global/bin/claude"));
+
+  return out;
+}
 function resolveClaude() {
   if (process.env.CLAUDE_BIN) {
     try {
@@ -54,11 +94,13 @@ function resolveClaude() {
     }
   }
 
+  const home = process.env.HOME || "";
   const candidates = [
     "/opt/homebrew/bin/claude",
     "/usr/local/bin/claude",
     "/usr/bin/claude",
-    join(process.env.HOME || "", ".local/bin/claude"),
+    join(home, ".local/bin/claude"),
+    ..._collectNodeManagerCandidates(home),
   ];
   for (const p of candidates) {
     try { accessSync(p, constants.X_OK); console.warn(`[init] CLAUDE_BIN not set, resolved to ${p}`); return p; } catch {}
@@ -72,6 +114,8 @@ function resolveClaude() {
   console.error(
     "FATAL: claude binary not found.\n" +
     "  Set CLAUDE_BIN=/path/to/claude or ensure claude is in PATH.\n" +
+    "  Hint: if you use nvm/fnm/asdf, set CLAUDE_BIN to the absolute path\n" +
+    "  shown by `which claude` in your interactive shell.\n" +
     "  Checked: " + candidates.join(", ")
   );
   process.exit(1);


### PR DESCRIPTION
## Summary

`resolveClaude()` in `server.mjs` had a hardcoded candidate list covering only homebrew, `/usr/local`, `/usr/bin`, and `~/.local/bin`. macOS dev machines with nvm-managed Node + Claude CLI hit a startup FATAL until the user manually injected `CLAUDE_BIN` into the launchd plist. This PR extends the candidate list to cover the three common Node version managers (nvm/fnm/asdf) plus the npm-prefix-relocated `~/.npm-global/bin`, while preserving the existing CLAUDE_BIN override and `which` fallback.

## Bug evidence

Live test on a MacBook with nvm-installed Node + Claude CLI: `which claude` returned `/Users/<user>/.nvm/versions/node/v22.22.2/bin/claude`. server.mjs at startup printed:

```
FATAL: claude binary not found.
  Set CLAUDE_BIN=/path/to/claude or ensure claude is in PATH.
  Checked: /opt/homebrew/bin/claude, /usr/local/bin/claude, /usr/bin/claude, /<HOME>/.local/bin/claude
```

The user had to manually inject `CLAUDE_BIN=/<HOME>/.nvm/.../bin/claude` into the launchd plist EnvironmentVariables and reload.

## Fix description

New resolution order (first hit wins):

1. Explicit `CLAUDE_BIN` env var (unchanged — highest priority, fail-fast if non-executable)
2. Existing hardcoded list: `/opt/homebrew/bin/claude`, `/usr/local/bin/claude`, `/usr/bin/claude`, `$HOME/.local/bin/claude`
3. **NEW** — Node version manager paths enumerated dynamically via `readdirSync`:
   - nvm: `$HOME/.nvm/versions/node/<v>/bin/claude` (with `$HOME/.nvm/aliases/default` resolved and prepended)
   - fnm: `$HOME/.fnm/node-versions/<v>/installation/bin/claude`
   - asdf: `$HOME/.asdf/installs/nodejs/<v>/bin/claude`
   - npm-prefix-relocated: `$HOME/.npm-global/bin/claude`
4. `which claude` shell fallback (unchanged)
5. FATAL with the original message — now upgraded with a hint mentioning `CLAUDE_BIN`

Implementation details:
- One new helper `_collectNodeManagerCandidates(home)` plus a tiny `_listVersionDirs(parent)` wrapper that swallows ENOENT.
- `readdirSync` added to the existing `node:fs` import — no new external dependency.
- Single-file change.

## Smoke test results

Standalone test script that mirrors the resolver logic, plus the repo test suite:

| Scenario | Expectation | Result |
|---|---|---|
| Default (no `CLAUDE_BIN`) | Find `/opt/homebrew/bin/claude` (existing host) | ok, source=`candidate` |
| `CLAUDE_BIN=/nonexistent/claude` | Fail-fast with "not executable" | ok, fail-fast preserved |
| `HOME=/tmp/fakenvm` with synthetic `.nvm/versions/node/v22.22.2/bin/claude` symlink | Path appears in candidate list (and would be picked if homebrew absent) | ok, candidate present; alias-default unshift verified |
| `npm test` | All 43 unit tests pass | 43 passed, 0 failed |
| `node --check server.mjs` | Syntax OK | SYNTAX_OK |
| `alignment.yml` blacklist grep | No hits | BLACKLIST_CLEAR |

## ALIGNMENT.md / `cli.js` citation

> This is OCP-internal binary discovery — there is no `cli.js` operation to cite. ALIGNMENT.md Rule 2 (the rule that limits OCP to operations that exist in `cli.js`) does not constrain runtime path discovery for the OCP server itself.

## Iron Rule 10 reviewer

Independent reviewer required (per CLAUDE.md). The author cannot self-approve. Reviewer should verify:
- No `cli.js` operation exists for "find the claude binary on disk" — the cli.js-not-applicable statement is correct.
- The resolution order keeps explicit `CLAUDE_BIN` highest priority.
- The new helper does not introduce ENOENT/permission throws — `_listVersionDirs` swallows.

## Provenance

Identified during fresh-state Round 2 testing on MacBook.

## Test plan
- [x] `npm test` — 43/43 pass
- [x] `node --check server.mjs` — OK
- [x] Standalone resolver smoke tests (3 scenarios) — pass
- [x] Alignment blacklist grep — clear
- [ ] CI: alignment.yml workflow on this branch
- [ ] Reviewer opens this PR with fresh context and APPROVE per Iron Rule 10

DO NOT merge before independent review.