### PR TITLE
fix(setup): inject CLAUDE_BIN, OCP_ADMIN_KEY, PROXY_ANONYMOUS_KEY into service env

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -39,6 +39,29 @@ const PROVIDER_NAME = opt("provider-name", "claude-local");
 const BIND_ADDRESS = opt("bind", "127.0.0.1");
 const AUTH_MODE_CONFIG = opt("auth-mode", "none");
 
+// ── Service-env injection: CLAUDE_BIN, OCP_ADMIN_KEY, PROXY_ANONYMOUS_KEY ──
+// These are read from the user's shell env at install time and written into
+// the service unit (plist / systemd) so the daemon picks them up on boot.
+
+// CLAUDE_BIN — detect at install time; omit if not found (server.mjs fallback)
+let CLAUDE_BIN_INJECT = null;
+if (process.env.CLAUDE_BIN) {
+  CLAUDE_BIN_INJECT = process.env.CLAUDE_BIN;
+} else {
+  try {
+    const detected = execSync("which claude 2>/dev/null", { encoding: "utf-8" }).trim();
+    if (detected && existsSync(detected)) {
+      CLAUDE_BIN_INJECT = detected;
+    }
+  } catch { /* which not available or claude not on PATH — omit */ }
+}
+
+// OCP_ADMIN_KEY — omit entirely when empty/unset; don't write empty string
+const OCP_ADMIN_KEY_INJECT = process.env.OCP_ADMIN_KEY || null;
+
+// PROXY_ANONYMOUS_KEY — same pattern
+const PROXY_ANON_KEY_INJECT = process.env.PROXY_ANONYMOUS_KEY || null;
+
 // ── Models: derived from models.json (single source of truth) ──────────
 const modelsConfig = JSON.parse(readFileSync(join(__dirname, "models.json"), "utf-8"));
 
@@ -286,6 +309,29 @@ banner.push(`╚═════════════════════�
 console.log("\n" + banner.join("\n") + "\n");
 
 // ── Step 7: Install auto-start on boot ──────────────────────────────────
+
+// Log service-env injection plan (shown in both dry-run and live mode)
+console.log("\n🔧 Service unit env vars to inject:\n");
+if (CLAUDE_BIN_INJECT) {
+  log(`CLAUDE_BIN: ${CLAUDE_BIN_INJECT}`);
+} else {
+  log(`CLAUDE_BIN: (not found — server.mjs will auto-detect at runtime)`);
+}
+if (OCP_ADMIN_KEY_INJECT) {
+  log(`OCP_ADMIN_KEY: injected (length: ${OCP_ADMIN_KEY_INJECT.length})`);
+} else {
+  log(`OCP_ADMIN_KEY: (unset — admin endpoints disabled)`);
+}
+if (PROXY_ANON_KEY_INJECT) {
+  log(`PROXY_ANONYMOUS_KEY: injected (set)`);
+} else {
+  log(`PROXY_ANONYMOUS_KEY: (unset — anonymous access disabled)`);
+}
+
+if (DRY_RUN) {
+  console.log("\n  [dry-run] would write service unit with above env vars\n");
+}
+
 if (!DRY_RUN) {
   console.log("\n🔄 Installing auto-start on login...\n");
 
@@ -358,7 +404,13 @@ if (!DRY_RUN) {
     <key>CLAUDE_BIND</key>
     <string>${BIND_ADDRESS}</string>
     <key>CLAUDE_AUTH_MODE</key>
-    <string>${AUTH_MODE_CONFIG}</string>
+    <string>${AUTH_MODE_CONFIG}</string>${CLAUDE_BIN_INJECT ? `
+    <key>CLAUDE_BIN</key>
+    <string>${CLAUDE_BIN_INJECT}</string>` : ""}${OCP_ADMIN_KEY_INJECT ? `
+    <key>OCP_ADMIN_KEY</key>
+    <string>${OCP_ADMIN_KEY_INJECT}</string>` : ""}${PROXY_ANON_KEY_INJECT ? `
+    <key>PROXY_ANONYMOUS_KEY</key>
+    <string>${PROXY_ANON_KEY_INJECT}</string>` : ""}
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -396,7 +448,7 @@ After=network.target
 ExecStart=${nodeBin} ${serverPath}
 Environment=CLAUDE_PROXY_PORT=${PORT}
 Environment=CLAUDE_BIND=${BIND_ADDRESS}
-Environment=CLAUDE_AUTH_MODE=${AUTH_MODE_CONFIG}
+Environment=CLAUDE_AUTH_MODE=${AUTH_MODE_CONFIG}${CLAUDE_BIN_INJECT ? `\nEnvironment=CLAUDE_BIN=${CLAUDE_BIN_INJECT}` : ""}${OCP_ADMIN_KEY_INJECT ? `\nEnvironment=OCP_ADMIN_KEY=${OCP_ADMIN_KEY_INJECT}` : ""}${PROXY_ANON_KEY_INJECT ? `\nEnvironment=PROXY_ANONYMOUS_KEY=${PROXY_ANON_KEY_INJECT}` : ""}
 Restart=always
 RestartSec=5
 StandardOutput=append:${logPath}


### PR DESCRIPTION
## Summary

- `setup.mjs` now reads three env vars from the user's shell at install time and writes them into the service unit (`EnvironmentVariables` dict on macOS plist, `Environment=` lines on Linux systemd unit), so the daemon inherits them on boot — not just in the current shell session.
- No new CLI flags. No changes to `server.mjs`, `README.md`, `ocp`, `ocp-connect`, or `package.json`.

## Bug evidence

### Gap #2 — `OCP_ADMIN_KEY` broken in multi-mode

User exports `OCP_ADMIN_KEY=...` then runs `node setup.mjs --bind 0.0.0.0 --auth-mode multi`. The generated plist/systemd unit only contained `CLAUDE_PROXY_PORT` / `CLAUDE_BIND` / `CLAUDE_AUTH_MODE`. On boot, `process.env.OCP_ADMIN_KEY` was empty → admin endpoint validation always failed. Only the `localhost-permissive` code path silently succeeded for same-host callers.

### Gap #1 partial — `CLAUDE_BIN` not auto-detected into service unit

On macOS with nvm-installed Node, `which claude` resolves to a versioned nvm path (e.g. `~/.nvm/versions/node/v22.22.2/bin/claude`) that is not in server.mjs's hardcoded discovery list. `setup.mjs` now runs `which claude` at install time and bakes the resolved path into the service unit, so the daemon always starts with the correct binary — even on older server.mjs deployments.

### Gap #6 partial — `PROXY_ANONYMOUS_KEY` not injected

README §Anonymous Access tells users to `export PROXY_ANONYMOUS_KEY=... && ocp start`. The key lived only in the shell session and was never written into the service unit. On daemon restart it was gone.

## Fix design

Three new top-level constants computed before any file writes:

| Key | Source | Condition |
|-----|--------|-----------|
| `CLAUDE_BIN` | `$CLAUDE_BIN` env → `which claude` → omit | Always attempt detection; omit if not found |
| `OCP_ADMIN_KEY` | `$OCP_ADMIN_KEY` | Omit entirely if empty/unset (server.mjs treats `""` as "no admin") |
| `PROXY_ANONYMOUS_KEY` | `$PROXY_ANONYMOUS_KEY` | Omit entirely if empty/unset |

Injection is conditional in both platform branches:
- **macOS**: extra `<key>/<string>` pairs inside the `<dict>` of `EnvironmentVariables`
- **Linux**: extra `Environment=KEY=VALUE` lines in `[Service]`

Logging runs **outside** the `if (!DRY_RUN)` guard, so `--dry-run` shows exactly which keys would be written. Secret values are never logged — only their length (`OCP_ADMIN_KEY: injected (length: NN)`) or presence (`PROXY_ANONYMOUS_KEY: injected (set)`).

## Smoke test results (Mac mini, prod host — dry-run only)

```
$ node setup.mjs --dry-run --port 3479

🔧 Service unit env vars to inject:

  ✓ CLAUDE_BIN: /opt/homebrew/bin/claude
  ✓ OCP_ADMIN_KEY: (unset — admin endpoints disabled)
  ✓ PROXY_ANONYMOUS_KEY: (unset — anonymous access disabled)

  [dry-run] would write service unit with above env vars
```

With all three set:
```
$ OCP_ADMIN_KEY=testadminkey123 PROXY_ANONYMOUS_KEY=testanonkey456 CLAUDE_BIN=/usr/local/bin/claude \
    node setup.mjs --dry-run --port 3479 | grep -A 6 "Service unit"

🔧 Service unit env vars to inject:

  ✓ CLAUDE_BIN: /usr/local/bin/claude
  ✓ OCP_ADMIN_KEY: injected (length: 15)
  ✓ PROXY_ANONYMOUS_KEY: injected (set)

  [dry-run] would write service unit with above env vars
```

Pre-flight gate passed: `launchctl list | grep dev.ocp.proxy` returned a hit → dry-run only, no `launchctl bootstrap` executed.

## Secret-handling notes

- Secret values (`OCP_ADMIN_KEY`, `PROXY_ANONYMOUS_KEY`) are never logged. Only length or set/unset is reported.
- The plist (`~/Library/LaunchAgents/dev.ocp.proxy.plist`) is user-readable only on macOS. The systemd unit (`~/.config/systemd/user/ocp-proxy.service`) inherits user permissions. Both are consistent with current behavior.

## Scope

`setup.mjs` only — single layer, single PR per Iron Rule 11. Identified during fresh-state Round 2 testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)