### PR TITLE
docs(install): remove false symlink claim, fix Anonymous mode startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ The setup script will:
 1. Verify Claude CLI is installed and authenticated
 2. Start the proxy on port 3456
 3. Install auto-start (launchd on macOS, systemd on Linux)
-4. Symlink `ocp` to `/usr/local/bin` for CLI access
+
+After install the `ocp` CLI lives at `~/ocp/ocp`. To put it on your PATH, either symlink it manually (`ln -sf ~/ocp/ocp ~/.local/bin/ocp` if `~/.local/bin` is on your PATH, or `sudo ln -sf ~/ocp/ocp /usr/local/bin/ocp` for a system-wide symlink) or add an alias (`alias ocp=~/ocp/ocp`). Otherwise invoke it as `~/ocp/ocp <subcommand>`. The rest of this README assumes `ocp` is on your PATH.
 
 **Single-machine use** — just set your IDE to use the proxy:
 ```bash
@@ -395,10 +396,14 @@ In `multi` mode, the admin can designate a single well-known "anonymous" key tha
 
 **Enable**:
 
+The anonymous key is wired into the service unit (launchd plist on macOS, systemd unit on Linux) at install time. Export `PROXY_ANONYMOUS_KEY` in your shell before running `setup.mjs`, and `setup.mjs` will write it into the service unit env so the auto-started proxy picks it up:
+
 ```bash
 export PROXY_ANONYMOUS_KEY=ocp_public_anon   # or any string of your choice
-ocp start                                    # or however you start the server
+node setup.mjs --bind 0.0.0.0 --auth-mode multi
 ```
+
+If OCP is already installed without it, re-export the env var and re-run `node setup.mjs` (the installer is idempotent — it refreshes the service unit). Then `ocp restart` so the running proxy picks up the new env. Setting `PROXY_ANONYMOUS_KEY` only in your interactive shell **does not** affect the auto-started proxy — the service unit is the source of truth for its environment.
 
 **Client side**: the anonymous key value is exposed via `GET /health` as the field `anonymousKey` (null when not set). Clients like `ocp-connect` can auto-discover and use it, so the end user doesn't need to get a personal key from the admin.
 


### PR DESCRIPTION
## Summary

Fix three README inaccuracies identified during fresh-state install testing on Pi231 + MacBook (Round 1+2). Doc-only — no `server.mjs` change, no version bump.

## Doc lies / inaccuracies fixed

1. **§Server Setup falsely claimed `setup.mjs` symlinks `ocp` to `/usr/local/bin`.** It doesn't. `setup.mjs` writes `start.sh` + the launchd plist / systemd unit and stops there — there is no PATH symlink step. Removed the false line and added a short tip right after the install summary showing the user's real options: manual symlink to `~/.local/bin/ocp` or `/usr/local/bin/ocp`, or a shell alias, or invoking `~/ocp/ocp <subcommand>` directly.

2. **§Anonymous Access told users to run `ocp start`.** There is no such subcommand. Verified by running `~/ocp/ocp` — available commands are `usage`, `status`, `health`, `settings`, `logs`, `models`, `sessions`, `clear`, `keys`, `lan`, `connect`, `restart`, `update`. No `start`. Replaced with the correct flow: export `PROXY_ANONYMOUS_KEY`, then `node setup.mjs --bind 0.0.0.0 --auth-mode multi`.

3. **§Anonymous Access implied exporting `PROXY_ANONYMOUS_KEY` in an interactive shell was enough.** It isn't — the running proxy is auto-started by launchd / systemd from the service unit's own environment, not from the user's shell. Spelled this out and noted that if OCP was installed before exporting the env var, the user must re-run `setup.mjs` (idempotent) so the service unit env is refreshed, then `ocp restart`.

## Forward compatibility note

The `PROXY_ANONYMOUS_KEY` mechanism described in this README becomes 100% accurate the moment PR B (`fix/setup-inject-service-env`, the sibling PR landing alongside this one) merges. `setup.mjs` on current `main` does not yet read `PROXY_ANONYMOUS_KEY` and inject it into the service unit env — PR B is the code-side fix; this PR is the doc-side fix. Either order of merge is fine; together they make install truthful.

## Constraints respected

- No `server.mjs` change → no `cli.js` citation required.
- No `setup.mjs`, `ocp`, `ocp-connect`, or `models.json` change.
- No version bump, no `CHANGELOG.md` entry (doc-only).
- Minimum-diff: only the two paragraphs that contained the lies were touched. All other README content is byte-identical.

## Test plan

- [x] `~/ocp/ocp` (no args) enumerated — confirms no `start` subcommand exists.
- [x] `setup.mjs` source — confirmed no `/usr/local/bin/ocp` symlink code path.
- [x] Re-read §Server Setup install summary + §Anonymous Access end-to-end as a fresh user; no contradiction with reality.
- [ ] Reviewer to load the GitHub UI Files-changed preview and confirm rendered Markdown is clean.