### PR TITLE
docs(readme): add engineering-story backlink to 知乎 article + badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCP — Open Claude Proxy
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![GitHub release](https://img.shields.io/github/v/release/dtzp555-max/ocp)](https://github.com/dtzp555-max/ocp/releases) [![Buy Me a Coffee](https://img.shields.io/badge/Buy_Me_a_Coffee-ffdd00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/dtzp555)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![GitHub release](https://img.shields.io/github/v/release/dtzp555-max/ocp)](https://github.com/dtzp555-max/ocp/releases) [![Read the story](https://img.shields.io/badge/blog-engineering_story-555.svg)](https://zhuanlan.zhihu.com/p/2036388634207770402) [![Buy Me a Coffee](https://img.shields.io/badge/Buy_Me_a_Coffee-ffdd00?logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/dtzp555)
 
 > **Already paying for Claude Pro/Max? Use your subscription as an OpenAI-compatible API — $0 extra cost.**
 
@@ -51,6 +51,8 @@ OCP and the alternatives serve adjacent but distinct needs. Pick the one that fi
 **Plain English**: `claude-code-router` is the routing-and-switching power tool — pick it if you want to mix Anthropic, OpenAI, Gemini, and local models behind one endpoint. `anthropic-proxy` is the minimal forwarder. **OCP focuses on disciplined `cli.js`-aligned forwarding plus subscription multiplexing** — pick it if you want to share one Claude Pro/Max subscription across IDEs, devices, and people, with LAN auth, quotas, and a governance contract that prevents endpoint drift.
 
 OCP is single-maintainer + LLM-assisted, currently pre-1.0. It runs the maintainer's daily Claude Code workflow. If something breaks, [open an issue](https://github.com/dtzp555-max/ocp/issues).
+
+> 📖 **Engineering philosophy + the 9-day hallucinated `/api/oauth/usage` drift incident** that made `cli.js` alignment binding: [知乎专栏文章](https://zhuanlan.zhihu.com/p/2036388634207770402)
 
 ## Supported Tools
 


### PR DESCRIPTION
## Summary

Two small touches to README that point at a Chinese-language engineering blog article:

https://zhuanlan.zhihu.com/p/2036388634207770402

The article tells the story of OCP's `cli.js` alignment discipline — the 2026-04-11 9-day hallucinated `/api/oauth/usage` drift incident, the three-tier guardrail design (`ALIGNMENT.md` + `alignment.yml` + Iron Rule 10), and the recent fresh-state E2E pass that produced PRs #74-#78.

## Changes

1. **Badges row** — added a "blog · engineering story" shield between Release and Buy Me a Coffee. Maintains the row's visual rhythm.
2. **§Why OCP? closing line** — a single blockquote pointing at the article, between the existing single-maintainer disclosure and §Supported Tools.

Both are factual, no marketing voice.

## Doc-only

`server.mjs` not modified. ALIGNMENT.md Rule 5 (cli.js citation) does not apply. Same pattern as #68 / #69 / #71 / #78 / #79.

## Test plan

- [x] `git diff --stat` confirms README.md only (+3/-1)
- [x] No alignment.yml blacklist tokens introduced
- [x] Both new shield URL and 知乎 article link verified to be reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)