### PR TITLE
fix(security): /api/usage default scope = self; admin all-keys requires ?all=true

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -55,7 +55,13 @@
 </div>
 
 <div class="section">
-  <h2>Usage by Key</h2>
+  <div class="flex" style="justify-content: space-between; align-items: center;">
+    <h2 style="margin: 0;">Usage by Key</h2>
+    <label id="usage-scope-toggle" class="flex" style="display:none; gap: 0.4rem; font-size: 0.8rem; color: #94a3b8; cursor: pointer;">
+      <input type="checkbox" id="usage-show-all" style="cursor: pointer;">
+      <span>Show all keys</span>
+    </label>
+  </div>
   <table id="key-usage-table">
     <thead><tr><th>Key</th><th>Requests</th><th>OK</th><th>Err</th><th>Avg Time</th><th>Last Request</th></tr></thead>
     <tbody></tbody>
@@ -170,7 +176,8 @@ async function refreshStatus() {
 
 async function refreshUsage() {
   try {
-    const data = await api("/api/usage");
+    const showAll = localStorage.getItem("ocp_usage_show_all") === "1";
+    const data = await api(showAll ? "/api/usage?all=true" : "/api/usage");
     const tbody = document.querySelector("#key-usage-table tbody");
     tbody.innerHTML = (data.byKey || []).map(k => `
       <tr>
@@ -204,6 +211,8 @@ async function refreshKeys() {
   try {
     const data = await api("/api/keys");
     document.getElementById("key-mgmt-section").style.display = "";
+    // Admin-only "Show all keys" toggle for /api/usage scope.
+    document.getElementById("usage-scope-toggle").style.display = "flex";
     const tbody = document.querySelector("#keys-table tbody");
     tbody.innerHTML = (data.keys || []).map(k => `
       <tr>
@@ -239,6 +248,16 @@ async function refreshAll() {
   await Promise.all([refreshStatus(), refreshUsage(), refreshKeys()]);
   document.getElementById("refresh-indicator").textContent = `Updated ${new Date().toLocaleTimeString()}`;
 }
+
+// Wire "Show all keys" toggle (visibility gated to admin via refreshKeys()).
+(function setupUsageScopeToggle() {
+  const cb = document.getElementById("usage-show-all");
+  cb.checked = localStorage.getItem("ocp_usage_show_all") === "1";
+  cb.addEventListener("change", () => {
+    localStorage.setItem("ocp_usage_show_all", cb.checked ? "1" : "0");
+    refreshUsage();
+  });
+})();
 
 refreshAll();
 setInterval(refreshAll, 30000);

--- a/server.mjs
+++ b/server.mjs
@@ -1616,14 +1616,45 @@ const server = createServer(async (req, res) => {
   }
 
   if (req.url?.startsWith("/api/usage") && req.method === "GET") {
-    if (!isAdmin) return jsonResponse(res, 403, { error: "Admin access required" });
+    // Least-privilege scope rules (security audit follow-up):
+    //   - non-admin authenticated key  → only own rows
+    //   - anonymous (PROXY_ANONYMOUS_KEY) → only "anonymous" rows; ?all=true ignored
+    //   - admin without ?all=true       → only own ("admin") rows
+    //   - admin with    ?all=true       → full byKey/recent (legacy behavior); audited
+    // Authenticated callers are required (anyone reaching here passed the auth gate above);
+    // remote+no-auth requests would have been rejected before this point.
     const url = new URL(req.url, `http://${BIND_ADDRESS}:${PORT}`);
     const since = url.searchParams.get("since");
     const until = url.searchParams.get("until");
+    const wantAll = url.searchParams.get("all") === "true";
+    const callerName = req._authKeyName;
+
+    // Anonymous callers may never opt into all-keys view, even if they pass ?all=true.
+    const isAnonCaller = callerName === "anonymous";
+    const fullScope = isAdmin && wantAll && !isAnonCaller;
+
+    // scopeName === null when fullScope is true (no filter); otherwise the key_name to filter by.
+    const scopeName = fullScope ? null : callerName;
+
+    if (fullScope) {
+      logEvent("info", "admin_usage_full_scope", { caller: callerName, ip: req.socket.remoteAddress || null });
+    }
+
+    const byKeyAll = getUsageByKey({ since, until });
+    const recentAll = getRecentUsage(Math.min(parseInt(url.searchParams.get("limit") || "50", 10), 500));
+    const timeline = getUsageTimeline({
+      keyName: scopeName || undefined,
+      hours: Math.min(parseInt(url.searchParams.get("hours") || "24", 10), 720),
+    });
+
+    const byKey = scopeName ? byKeyAll.filter((row) => row.key_name === scopeName) : byKeyAll;
+    const recent = scopeName ? recentAll.filter((row) => row.key_name === scopeName) : recentAll;
+
     return jsonResponse(res, 200, {
-      byKey: getUsageByKey({ since, until }),
-      timeline: getUsageTimeline({ hours: Math.min(parseInt(url.searchParams.get("hours") || "24", 10), 720) }),
-      recent: getRecentUsage(Math.min(parseInt(url.searchParams.get("limit") || "50", 10), 500)),
+      byKey,
+      timeline,
+      recent,
+      scope: { self: scopeName, all: fullScope },
     });
   }
 


### PR DESCRIPTION
## Summary

Currently `/api/usage` returns the full per-key usage byKey + recent + timeline block to any caller authenticated as admin (`server.mjs:1618-1628`). A brief admin-token compromise therefore exposes every household member's request volume, request timing, and which-model — metadata, but sensitive metadata. This PR moves `/api/usage` to least-privilege: callers see **only their own** usage by default; admin sees-all only with explicit `?all=true`, and that escalation moment is logged.

Identified during privacy/security audit — `.claude/research/ocp-security-audit.md` §3.

## Behavior matrix

| Caller | Default scope | `?all=true` |
|---|---|---|
| anonymous (`PROXY_ANONYMOUS_KEY`) | own (`"anonymous"` rows) | **ignored** — still own only |
| authenticated non-admin key | own (`key_name` rows) | **ignored** — still own only |
| admin (no flag) | own (`"admin"` rows) | n/a |
| admin with `?all=true` | n/a | full byKey/recent (legacy behavior) |
| localhost-no-token (`"local"`) | own (`"local"` rows) | full (existing localhost = isAdmin convention) |

Response shape stays the same. An advisory `scope: { self, all }` field is added so dashboards can surface which view they are seeing, but the existing `byKey` / `recent` / `timeline` keys are unchanged in structure — they just contain less data unless the caller explicitly opts in.

## Audit-friendly addition

When admin opts into `?all=true`, the server now emits:

```json
{"level":"info","event":"admin_usage_full_scope","caller":"admin","ip":"<remote>"}
```

so every privilege-escalation moment is recorded in the proxy log.

## ⚠ Backward-compat warning (admin tooling only)

This is a deliberate breaking change for least-privilege.

Existing **admin** scripts / cron jobs that call `/api/usage` to inventory **all** keys **must add `?all=true`** after this change. Without the flag, they will see only the admin key's own usage. Non-admin tooling continues to work — and is now safer because anonymous / per-key callers cannot pull other keys' data even if they try `?all=true`.

## Dashboard UX (dashboard.html)

A new "Show all keys" checkbox is added next to the "Usage by Key" section heading.

- **Hidden by default.** It is only revealed when `refreshKeys()` succeeds (the same admin gate that already controls the API Keys management section), so non-admin users in the LAN never see it.
- **State persists in `localStorage`** as `ocp_usage_show_all` (values `"0"` / `"1"`), so an admin's preference survives page reloads.
- **Toggling refetches** `/api/usage?all=true` (or the bare endpoint), and the existing 30-second auto-refresh respects whatever the toggle is currently set to.

## `cli.js` citation

> This is OCP-internal admin API behavior — there is no `cli.js` operation to cite. `ALIGNMENT.md` Rule 2 (the rule that limits OCP to operations that exist in `cli.js`) does not constrain access-control rules for the OCP server's own admin endpoints.

## Smoke test results

Isolated test server spun up on :3489 with seed DB containing four `key_name`s (`admin`, `alice`, `bob`, `anonymous`) and 10 fake usage rows. **Prod :3478 was not touched.**

| Scenario | Expected | Result |
|---|---|---|
| `node --check server.mjs` | syntax OK | SYNTAX_OK |
| `npm test` | 43/43 unit tests pass | 43 passed, 0 failed |
| `alignment.yml` blacklist grep | no hits | BLACKLIST_CLEAR |
| LAN: alice no `?all` | scope=self, byKey=`[alice]` | ok |
| LAN: alice `?all=true` | escalation **denied**, byKey=`[alice]` | ok |
| LAN: bob no `?all` | scope=self, byKey=`[bob]` | ok |
| LAN: anon `?all=true` | escalation **denied**, byKey=`[anonymous]` | ok |
| LAN: admin no `?all` | scope=self, byKey=`[admin]` | ok |
| LAN: admin `?all=true` | full 4 keys + audit log emitted | ok (event `admin_usage_full_scope` with `caller=admin, ip=172.16.2.30`) |
| LAN: bogus token | 401 | ok |
| `GET /dashboard` HTML | contains `usage-show-all`, `usage-scope-toggle`, `ocp_usage_show_all`, `?all=true` references | 8 references located |

Test server torn down before commit; `lsof -nP -iTCP:3489` confirmed port free.

## Iron Rule 10

Author cannot self-approve. An independent reviewer (fresh context, per `CLAUDE.md` § "Hard requirements for `server.mjs` changes") must:

- Verify the `cli.js`-not-applicable statement holds — there is no `cli.js` operation that performs administrative log filtering for an OCP-style proxy.
- Confirm anonymous + non-admin keys cannot escalate to all-keys view via `?all=true` (the `isAdmin` and `isAnonCaller` gates).
- Confirm `admin_usage_full_scope` is logged exactly when, and only when, scope expansion happens.
- Confirm the dashboard toggle is gated to admin (revealed only inside `refreshKeys()` success branch, which is itself behind admin auth).

## Test plan
- [x] `npm test` — 43/43 pass
- [x] `node --check server.mjs` — OK
- [x] Alignment blacklist grep — clear
- [x] Isolated LAN scope matrix — pass (8/8 cases)
- [x] Dashboard HTML toggle elements present in served output
- [x] `admin_usage_full_scope` audit log emitted only for admin+`?all=true`
- [ ] CI: alignment.yml + test.yml on this branch
- [ ] Reviewer opens this PR with fresh context and APPROVE per Iron Rule 10

DO NOT merge before independent review. DO NOT bump version — this lands as a follow-up release PR after PR-N reviewer approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)