### PR TITLE
chore(release): v3.14.0 — security hardening (sessions namespacing + file modes + /api/usage scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v3.14.0 — 2026-05-10
+
+### Features (security hardening)
+
+- **Per-key session isolation** (PR #86, S1) — the `sessions` Map in `server.mjs` is now keyed by `${keyName}|${conversationId}` instead of bare `conversationId`. Before this fix, two clients using distinct API keys but the same `session_id` value (e.g. both defaulting to `"default"`) would share the same `cli.js` subprocess and conversation history, creating a cross-tenant leak path. Post-fix each (key, session) pair is isolated end-to-end, extending the per-key cache isolation shipped in v3.13.0 D1 to the session layer.
+- **On-disk credential file modes 0700/0600** (PR #87, S2) — `setup.mjs` now creates `~/.ocp` at mode 0700 and both `admin-key` and `ocp.db` at mode 0600. An idempotent `reconcileFileModes()` call in `server.mjs` startup tightens any existing installation to these modes automatically on every launch, so existing prod boxes fix themselves without manual `chmod`. Before this fix, all three files were created at the process's default umask (typically world-readable 0644 / 0755), leaving plaintext credentials readable by other local users.
+- **`/api/usage` default scope = self; admin all-keys requires `?all=true`** (PR #88, S3) — the usage endpoint now applies a least-privilege default: anonymous callers receive only their own rows, non-admin authenticated callers receive only their own rows, and admin callers receive only their own rows unless they explicitly pass `?all=true`. When `?all=true` is used, an audit log line is emitted. Before this fix, any admin-token holder could silently enumerate usage data for every key on the server.
+
+### Behavior changes
+
+- **Breaking change for admin tooling**: `/api/usage` no longer returns all-keys data by default. Existing cron jobs, dashboards, or scripts that rely on the admin token seeing all-keys output must add `?all=true` to their request URL after upgrading to v3.14.0.
+- **File mode reconcile at server startup** logs a one-line notice per path when mode is tightened (e.g. `[security] tightened ~/.ocp/ocp.db → 0600`). No action is required from the operator; the reconcile is idempotent and silent when modes are already correct.
+- **`sessions` Map key is now `${keyName}|${conversationId}` internally.** No client-visible wire change — the `session_id` field in request/response is unchanged.
+
+### Verification
+
+- Stress-test pass: 11/11 phases including S1/S2/S3 security regression checks (Phase E, I, J). 35-minute sustained run, 60 calls, 0 errors, 0 timeouts. RSS dropped 51→47 MB across the window. Per-key cache isolation, singleflight, cache_control bypass, quota enforcement, file-mode reconcile, and scope guard against escalation all verified against running code.
+
+### Governance
+
+- All three PRs (#86, #87, #88) include the explicit `cli.js`-citation-not-applicable disclaimer (per PR #75 pattern) since they are OCP-internal access-control, session-state, and file-permission changes with no corresponding `cli.js` operation to cite.
+
+### No new env vars / no public API surface change beyond the documented breaking change
+
+This release adds no new env vars or endpoints. The only externally visible change is the `/api/usage` scope guard (breaking for admin all-keys consumers; see Behavior changes above).
+
 ## v3.13.0 — 2026-05-07
 
 ### Features (cache layer hardening)

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ ocp keys revoke son-ipad   # Revoke a key
 | `shared` | `CLAUDE_AUTH_MODE=shared` + `PROXY_API_KEY=xxx` | Everyone shares one key |
 | `multi` | `CLAUDE_AUTH_MODE=multi` + `OCP_ADMIN_KEY=xxx` | Per-person keys with usage tracking (recommended) |
 
+> **Usage scope (v3.14.0+):** `/api/usage` returns the caller's own rows by default. Admin callers must pass `?all=true` to retrieve data for all keys; doing so emits an audit log line.
+
 ### Anonymous Access (optional)
 
 In `multi` mode, the admin can designate a single well-known "anonymous" key that bypasses `validateKey()` and grants public read/write access. This is useful for letting LAN users (or clients like OpenClaw multi-agent setups) connect without individual per-user keys.
@@ -460,6 +462,7 @@ When a key exceeds its quota, OCP returns HTTP 429 with a structured error:
 - Keys are stored in `~/.ocp/ocp.db` (SQLite, zero external dependencies)
 - Admin key is required for key management API endpoints
 - The dashboard (`/dashboard`) and health check (`/health`) are always public
+- File modes for `~/.ocp` (0700), `admin-key` + `ocp.db` (0600) are auto-tightened at server startup as of v3.14.0
 
 ## Built-in Usage Monitoring
 
@@ -657,7 +660,7 @@ The canonical list lives in [`models.json`](./models.json) — the single source
 | `/api/keys` | GET/POST | List or create API keys (admin only) |
 | `/api/keys/:id` | DELETE | Revoke an API key (admin only) |
 | `/api/keys/:id/quota` | GET/PATCH | View or set per-key quota (admin only) |
-| `/api/usage` | GET | Per-key usage stats (`?since=&until=&hours=&limit=`) |
+| `/api/usage` | GET | Per-key usage stats (`?since=&until=&hours=&limit=`); returns self only by default — pass `?all=true` (admin only) for all-keys data |
 | `/cache/stats` | GET | Cache statistics (admin only) |
 | `/cache` | DELETE | Clear response cache (admin only) |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

This is the release-metadata PR for v3.14.0. All functional changes are already merged in `main` via PRs #86, #87, and #88. This PR bumps the version, prepends the CHANGELOG entry, and adds the minimal README doc updates required by the release_kit overlay (Iron Rule 5.5).

**Files changed (3 only):** `package.json` (version bump), `CHANGELOG.md` (new entry), `README.md` (~5 lines doc).

---

## What's in this release

Three security fixes, already merged:

- **#86** `fix(security): namespace sessions Map by keyId` — `sessions` Map rekeyed to `${keyName}|${conversationId}`. Two clients sharing the same `session_id="default"` but different API keys no longer share a `cli.js` subprocess or conversation history. Closes a cross-tenant leak path.
- **#87** `fix(security): tighten on-disk credential file modes (700/600)` — `~/.ocp` dir 0700, `admin-key` + `ocp.db` 0600 on fresh install. Idempotent `reconcileFileModes()` at server startup auto-fixes existing prod boxes.
- **#88** `fix(security): /api/usage default scope = self; admin all-keys requires ?all=true` — least-privilege default for the admin metadata endpoint. Audit log emitted on full-scope admin opt-in.

---

## Breaking change warning

**Admin tooling must adapt.** `/api/usage` no longer returns all-keys data by default. Any cron job, dashboard, or script that relies on an admin token seeing all keys' usage must add `?all=true` to the request URL after upgrading to v3.14.0.

---

## Stress-test verification

35-minute sustained run, 60 calls, 11/11 phases passed (including S1/S2/S3 regression checks for each of the three security fixes). 0 errors, 0 timeouts. RSS 51→47 MB.

---

## Iron Rule 5.5 release_kit checklist

- [x] `version_source: package.json` — bumped `3.13.0` → `3.14.0`
- [x] `changelog: CHANGELOG.md` — v3.14.0 entry prepended with Features / Behavior changes / Verification / Governance sections
- [x] `docs_source: README.md` — `/api/usage` scope note in Auth Modes §; API Endpoints table row updated; file-mode bullet in Important Notes §
- [x] No new env vars — no Environment Variables table change needed
- [x] No new endpoints — existing `/api/usage` row updated in place
- [x] No new CLI subcommand
- [x] No bootstrap quirk — no Troubleshooting update needed
- [x] `release_channel: github-release` — tag `v3.14.0` push triggers `release.yml` auto-release (maintainer drives tag)

---

## cli.js citation N/A — explicit disclaimer

This release PR modifies no `server.mjs`, `setup.mjs`, or `keys.mjs`. The three underlying security PRs (#86, #87, #88) are OCP-internal access-control, session-state, and file-permission changes with no corresponding `cli.js` operation to cite. Each of those PRs carries an explicit `cli.js`-citation-not-applicable disclaimer per the PR #75 pattern, reviewed and merged by the maintainer. This release-metadata PR inherits that same disposition.

---

## Do not merge without independent review

Per Iron Rule 10 — implementation author may not self-approve. A fresh-context reviewer should confirm:
1. The three files changed match the spec above (no `server.mjs` / `setup.mjs` / `keys.mjs` touches).
2. CHANGELOG entry is complete and accurate.
3. README changes are ~5 lines and don't rewrite prose sections.
4. cli.js citation N/A disclaimer is present and correct.

## Do not tag from this PR

Tag `v3.14.0` is maintainer-driven. Pushing the tag triggers `.github/workflows/release.yml` which auto-creates the GitHub Release. Do not run `git tag` or `gh release create` from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)