### PR TITLE
fix(doctor): dynamic latest_version (v3.15.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v3.15.0 — 2026-XX-XX (release date filled at tag time)
+## v3.15.1 — 2026-05-10
+
+### Fixes
+
+- **doctor: dynamic `latest_version` from `origin/main:package.json`** — v3.15.0 doctor used a hard-coded `latest = "v3.14.0"` fallback, which made any v3.15.0+ install report `kind = upgrade` (against a stale value). `ocp update` would then attempt `git checkout v3.14.0` — a downgrade. Doctor now fetches `git -C ~/ocp show origin/main:package.json` to determine the actual latest version; on failure (offline, fresh clone with no remote), falls back to `currentVersion` so `kind = noop` instead of recommending a downgrade.
+
+## v3.15.0 — 2026-05-10
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -48,7 +48,19 @@ export async function runDoctor(opts = {}) {
       currentVersion = "unknown";
     }
   }
-  const latestVersion = opts.mockLatest || "v3.14.0";
+  // Resolve latest from origin/main (cheap: `git show origin/main:package.json`).
+  // Falls back to current_version when network/git unavailable, so kind = noop instead
+  // of recommending a downgrade against a stale hardcoded value.
+  let latestVersion = opts.mockLatest;
+  if (!latestVersion) {
+    try {
+      const out = execSync(`git -C ${ocpDir} show origin/main:package.json 2>/dev/null`, { stdio: ["pipe", "pipe", "pipe"] }).toString();
+      const remotePkg = JSON.parse(out);
+      latestVersion = `v${remotePkg.version}`;
+    } catch {
+      latestVersion = currentVersion;
+    }
+  }
   push("current_version", "PASS", `current=${currentVersion}`);
 
   // --- from-version supported? ---

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -655,6 +655,18 @@ test("doctor empty health body → fix_service (not fix_oauth)", async () => {
   assert.equal(result.next_action.kind, "fix_service");
 });
 
+test("doctor falls back to currentVersion when origin/main unreachable (no stale latest)", async () => {
+  // Use a non-existent ocpDir so git command fails; without the fix this would still
+  // hard-code v3.14.0 as latest and recommend a downgrade for a future v3.15.0+ user.
+  const result = await runDoctor({
+    skipNetwork: true,
+    mockVersion: "v3.15.0",
+    ocpDir: "/nonexistent-ocp-dir-for-test"
+  });
+  assert.equal(result.latest_version, "v3.15.0");
+  assert.equal(result.next_action.kind, "noop");
+});
+
 // ── Upgrade Tests ──
 import { runUpgrade } from "./scripts/upgrade.mjs";
 


### PR DESCRIPTION
## Summary

Caught during v3.15.0 post-deploy verification: `./ocp doctor` on a v3.15.0+ install reports `kind=upgrade` against a stale hardcoded `latest = "v3.14.0"`. `ocp update` would then `git checkout v3.14.0` — a downgrade.

Fix: doctor now reads `git -C ~/ocp show origin/main:package.json` to determine actual latest. Falls back to currentVersion on failure (offline, no remote, fresh clone) — gives `kind=noop` rather than recommending a downgrade.

## Severity

Production bug. Without this fix, v3.15.0 users running `ocp update` would silently downgrade themselves to v3.14.0 (and the snapshot/full-path machinery would all run for a downgrade).

## Test plan

- [x] `npm test` — 76 pass (1 new regression test added)
- [x] Manual: `./ocp doctor` against v3.15.0 install now correctly reports `current=v3.15.0 latest=v3.15.0 kind=noop`
- [x] Manual: `./ocp doctor` with unreachable git falls back to currentVersion (verified via test fixture)

## ALIGNMENT.md

No `cli.js` citation needed: OCP-internal doctor logic, no `server.mjs` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)