### PR TITLE
fix(plugin): default OCP plugin port to 3478 + env-overridable (v3.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## v3.16.0 — 2026-XX-XX (release date filled at tag time)
+## v3.16.1 — 2026-05-12
+
+### Fixes
+
+- **OCP plugin port lag** — `ocp-plugin/index.js` hard-coded `http://127.0.0.1:3456` while OCP server moved to 3478 in v3.14+. Result: `/ocp` slash commands in OpenClaw (e.g. `/ocp usage` from the home Telegram bot) returned "OCP error: fetch failed". Default is now `http://127.0.0.1:3478` and the plugin reads `OCP_PROXY_URL` env (full URL) or `CLAUDE_PROXY_PORT` env (port only) when set. `openclaw.plugin.json` `configSchema.proxyUrl.default` also updated and the plugin version bumped to `3.16.1`. Run `ocp update` to redeploy the plugin into `~/.openclaw/extensions/ocp/`.
+
+### Governance
+
+- No `cli.js` citation needed (no `server.mjs` change). ALIGNMENT.md Rule 2 not engaged.
+
+## v3.16.0 — 2026-05-10
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -855,7 +855,8 @@ Future `ocp update` invocations sync automatically.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CLAUDE_PROXY_PORT` | `3456` | Listen port |
+| `CLAUDE_PROXY_PORT` | `3478` | Listen port (server-side). Also consumed by the OpenClaw `ocp-plugin` to dial the local proxy. |
+| `OCP_PROXY_URL` | *(unset)* | Plugin-side full URL override (e.g. `http://10.0.0.5:3478`). Wins over `CLAUDE_PROXY_PORT` when both are set. Read by `ocp-plugin/index.js` only — server ignores it. |
 | `CLAUDE_BIND` | `127.0.0.1` | Bind address (`0.0.0.0` for LAN access) |
 | `CLAUDE_AUTH_MODE` | `none` | Auth mode: `none`, `shared`, or `multi` |
 | `OCP_ADMIN_KEY` | *(unset)* | Admin key for key management (multi mode) |

--- a/ocp-plugin/index.js
+++ b/ocp-plugin/index.js
@@ -1,9 +1,17 @@
 /**
  * OCP Plugin — registers /ocp as a native slash command in OpenClaw gateway.
- * Calls the local claude-proxy at http://127.0.0.1:3456 and formats the response.
+ * Calls the local claude-proxy and formats the response.
+ *
+ * Port resolution (in priority order):
+ *   1. OCP_PROXY_URL env (full URL, e.g. http://10.0.0.5:3478)
+ *   2. CLAUDE_PROXY_PORT env (port only; localhost assumed)
+ *   3. Fallback: http://127.0.0.1:3478 (OCP v3.14+ default)
+ *
+ * (The legacy 3456 default — pre-v3.14 — caused "OCP error: fetch failed"
+ * on machines whose OCP server moved to 3478 while the plugin lagged.)
  */
-
-const PROXY = "http://127.0.0.1:3456";
+const PROXY = process.env.OCP_PROXY_URL
+  || (process.env.CLAUDE_PROXY_PORT ? `http://127.0.0.1:${process.env.CLAUDE_PROXY_PORT}` : "http://127.0.0.1:3478");
 
 // Wrap output in monospace code block for Telegram/Discord alignment
 function mono(text) { return "```\n" + text + "\n```"; }

--- a/ocp-plugin/openclaw.plugin.json
+++ b/ocp-plugin/openclaw.plugin.json
@@ -2,15 +2,15 @@
   "id": "ocp",
   "name": "OCP Commands",
   "description": "Slash commands for the OpenClaw Proxy — /ocp usage, /ocp settings, /ocp health, etc.",
-  "version": "3.12.0",
+  "version": "3.16.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {
       "proxyUrl": {
         "type": "string",
-        "default": "http://127.0.0.1:3456",
-        "description": "URL of the Claude proxy"
+        "default": "http://127.0.0.1:3478",
+        "description": "URL of the Claude proxy. Overridable via OCP_PROXY_URL or CLAUDE_PROXY_PORT env."
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

`ocp-plugin/index.js` hard-coded `http://127.0.0.1:3456` since plugin creation. OCP server default moved to 3478 in v3.14+ (when the launchd label was renamed to `dev.ocp.proxy`). The plugin never got the memo.

**Symptom**: `/ocp usage` from OpenClaw bots (e.g. home Telegram bot 大内总管) returned `OCP error: fetch failed` because the plugin tried port 3456 (nothing listening).

**Diagnostic**: caught 2026-05-12. Mac mini OCP healthy on 3478; `lsof -iTCP:3456` empty; plugin `index.js:6` hardcoded `3456`.

## Fix

- Default `PROXY` → `http://127.0.0.1:3478`
- Read `OCP_PROXY_URL` env (full URL) first
- Else read `CLAUDE_PROXY_PORT` env (port only)
- Else fall back to 3478
- `openclaw.plugin.json` bumped 3.12.0 → 3.16.1 (now version-aligned with OCP)
- `package.json` bumped 3.16.0 → 3.16.1
- CHANGELOG entry added

## Tests
- 84/84 pass (no regression). No new tests — plugin isn't covered by test-features.mjs; behavior verified via live `curl :3478/usage` after hot-patching the deployed copy on home-mac.

## Ops note
The deployed copy at `~/.openclaw/extensions/ocp/index.js` was hot-patched live to unblock 大内总管 before this PR was opened. `ocp update` light path will overwrite that hot-patch with this PR's content once merged + tagged.

## ALIGNMENT
No cli.js citation: OCP-internal plugin, no server.mjs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)