### PR TITLE
fix(plugin): revert default to 3456 + correct v3.16.1 narrative; v3.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,32 @@
 # Changelog
 
-## v3.16.1 — 2026-05-12
+## v3.16.2 — 2026-05-12
 
-### Fixes
+### Fixes — corrects v3.16.1
 
-- **OCP plugin port lag** — `ocp-plugin/index.js` hard-coded `http://127.0.0.1:3456` while OCP server moved to 3478 in v3.14+. Result: `/ocp` slash commands in OpenClaw (e.g. `/ocp usage` from the home Telegram bot) returned "OCP error: fetch failed". Default is now `http://127.0.0.1:3478` and the plugin reads `OCP_PROXY_URL` env (full URL) or `CLAUDE_PROXY_PORT` env (port only) when set. `openclaw.plugin.json` `configSchema.proxyUrl.default` also updated and the plugin version bumped to `3.16.1`. Run `ocp update` to redeploy the plugin into `~/.openclaw/extensions/ocp/`.
+The v3.16.1 fix was directionally correct (plugin now reads env first, falls back to a hardcoded default) but **the narrative and the hardcoded default were both wrong**.
+
+What v3.16.1 said: "OCP server moved to 3478 default in v3.14+; plugin lagged at 3456."
+What is actually true:
+- **OCP server source default has been `3456` since `593d0dc` (initial release) and has never changed.** Every line in `server.mjs`, `setup.mjs`, and the `ocp` CLI still uses `3456` as the documented and code-level default.
+- The single OCP installation observed on `3478` is the maintainer's Mac mini, whose plist was rewritten with `--port 3478` during a PR #71 dogfood smoke-test accident on 2026-05-08 (see `~/.cc-rules/memory/learnings/subagent_setup_mjs_prod_host_collision.md`). The plist drift was never reconciled back to source default, and v3.16.1 incorrectly canonised the post-accident value as if it had been a release decision.
+
+This release:
+- Restores the plugin fallback to `http://127.0.0.1:3456` to match server source default.
+- Updates `openclaw.plugin.json` `configSchema.proxyUrl.default` back to `3456`.
+- Restores README §"Environment Variables" `CLAUDE_PROXY_PORT` default to `3456`.
+- Plugin reads `OCP_PROXY_URL` env (full URL) first, then `CLAUDE_PROXY_PORT` env (port only), then falls back to `3456`. Hosts whose OCP plist injects a non-default port must also inject the same `CLAUDE_PROXY_PORT` into the OpenClaw plist for the plugin to follow.
+- Maintainer's Mac mini plist was reverted from `3478` to `3456` as part of this release deploy (no source change reflects this; it was a one-host correction).
+
+### Governance
+
+- No `cli.js` citation needed (no `server.mjs` change). ALIGNMENT.md Rule 2 not engaged.
+
+## v3.16.1 — 2026-05-12 (superseded — narrative incorrect; see v3.16.2 erratum)
+
+### Fixes (as shipped — note erratum above)
+
+- **OCP plugin port lag** — `ocp-plugin/index.js` hard-coded `http://127.0.0.1:3456`. ~~While OCP server moved to 3478 in v3.14+,~~ **(corrected v3.16.2: no such move ever happened.)** The Mac mini's plist was on `3478` only as residue from a dogfood accident. Result: `/ocp` slash commands from the home Telegram bot returned "OCP error: fetch failed". v3.16.1 changed the plugin default to `3478` (wrong direction; v3.16.2 reverts to `3456`).
 
 ### Governance
 

--- a/README.md
+++ b/README.md
@@ -855,8 +855,8 @@ Future `ocp update` invocations sync automatically.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CLAUDE_PROXY_PORT` | `3478` | Listen port (server-side). Also consumed by the OpenClaw `ocp-plugin` to dial the local proxy. |
-| `OCP_PROXY_URL` | *(unset)* | Plugin-side full URL override (e.g. `http://10.0.0.5:3478`). Wins over `CLAUDE_PROXY_PORT` when both are set. Read by `ocp-plugin/index.js` only — server ignores it. |
+| `CLAUDE_PROXY_PORT` | `3456` | Listen port (server-side). Also consumed by the OpenClaw `ocp-plugin` to dial the local proxy. |
+| `OCP_PROXY_URL` | *(unset)* | Plugin-side full URL override (e.g. `http://10.0.0.5:3456`). Wins over `CLAUDE_PROXY_PORT` when both are set. Read by `ocp-plugin/index.js` only — server ignores it. |
 | `CLAUDE_BIND` | `127.0.0.1` | Bind address (`0.0.0.0` for LAN access) |
 | `CLAUDE_AUTH_MODE` | `none` | Auth mode: `none`, `shared`, or `multi` |
 | `OCP_ADMIN_KEY` | *(unset)* | Admin key for key management (multi mode) |

--- a/ocp-plugin/index.js
+++ b/ocp-plugin/index.js
@@ -3,15 +3,17 @@
  * Calls the local claude-proxy and formats the response.
  *
  * Port resolution (in priority order):
- *   1. OCP_PROXY_URL env (full URL, e.g. http://10.0.0.5:3478)
+ *   1. OCP_PROXY_URL env (full URL, e.g. http://10.0.0.5:3456)
  *   2. CLAUDE_PROXY_PORT env (port only; localhost assumed)
- *   3. Fallback: http://127.0.0.1:3478 (OCP v3.14+ default)
+ *   3. Fallback: http://127.0.0.1:3456 (OCP server source default since v1.0)
  *
- * (The legacy 3456 default — pre-v3.14 — caused "OCP error: fetch failed"
- * on machines whose OCP server moved to 3478 while the plugin lagged.)
+ * If a particular host's OCP plist injects a non-default CLAUDE_PROXY_PORT,
+ * the OpenClaw launchd plist for that host must also inject the same
+ * CLAUDE_PROXY_PORT into the plugin's env, or the plugin will fall back to
+ * 3456 and miss the server.
  */
 const PROXY = process.env.OCP_PROXY_URL
-  || (process.env.CLAUDE_PROXY_PORT ? `http://127.0.0.1:${process.env.CLAUDE_PROXY_PORT}` : "http://127.0.0.1:3478");
+  || (process.env.CLAUDE_PROXY_PORT ? `http://127.0.0.1:${process.env.CLAUDE_PROXY_PORT}` : "http://127.0.0.1:3456");
 
 // Wrap output in monospace code block for Telegram/Discord alignment
 function mono(text) { return "```\n" + text + "\n```"; }

--- a/ocp-plugin/openclaw.plugin.json
+++ b/ocp-plugin/openclaw.plugin.json
@@ -2,14 +2,14 @@
   "id": "ocp",
   "name": "OCP Commands",
   "description": "Slash commands for the OpenClaw Proxy — /ocp usage, /ocp settings, /ocp health, etc.",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {
       "proxyUrl": {
         "type": "string",
-        "default": "http://127.0.0.1:3478",
+        "default": "http://127.0.0.1:3456",
         "description": "URL of the Claude proxy. Overridable via OCP_PROXY_URL or CLAUDE_PROXY_PORT env."
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

Maintainer asked "why was the port changed to 3478?" My v3.16.1 CHANGELOG said "OCP server moved to 3478 default in v3.14+." Investigation via `git log -G "3478" -- setup.mjs server.mjs` shows **that never happened**. Source default has been `3456` since `593d0dc` (initial release).

The Mac mini's plist was on `3478` only as residue from a 2026-05-08 PR #71 dogfood smoke-test accident. v3.16.1 mistakenly canonised the post-accident port as the new default and changed the plugin's fallback to match the wrong number.

## Fix

- `ocp-plugin/index.js` fallback → `http://127.0.0.1:3456`
- `openclaw.plugin.json` `configSchema.proxyUrl.default` → `http://127.0.0.1:3456`
- README §"Environment Variables" `CLAUDE_PROXY_PORT` default → `3456`
- `package.json` → 3.16.2
- CHANGELOG: v3.16.2 entry + v3.16.1 marked superseded with erratum text

PR #95's env-reading path (`OCP_PROXY_URL → CLAUDE_PROXY_PORT → fallback`) **stays**. Only the hardcoded fallback default changes.

Mac mini's plist was reverted 3478→3456 as part of the v3.16.2 deploy (per-host correction; not in source).

## Process note

This PR exists because I violated Iron Rule 2 (evidence-first) when writing v3.16.1's CHANGELOG — I asserted history without running `git log`. The fix should serve as a reminder that any "X was changed in version Y" claim in a commit/CHANGELOG must be backed by a grep.

## Tests
- 84/84 pass (no regression)

## ALIGNMENT
No cli.js citation: plugin + docs only, no server.mjs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)