### PR TITLE
fix(scripts): default CLAUDE_PROXY_PORT to 3456 (completes v3.16.2 revert)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v3.16.3 — 2026-05-13
+
+### Fixes — completes v3.16.2 port-drift revert
+
+v3.16.2 reverted the plugin / `openclaw.plugin.json` / README / Mac mini
+plist back to `3456` (the historical source default since `593d0dc`), but
+missed three places in `scripts/` that still defaulted to `3478`. Those
+three lines were the residual cascade source: every time `ocp doctor` or
+`ocp upgrade` ran without `CLAUDE_PROXY_PORT` in the env, they probed
+`3478`, reported "OCP not responding" against a healthy 3456 instance,
+and (in the case of OpenClaw sync follow-ups on the maintainer's host)
+re-introduced 3478 into downstream config.
+
+Changes:
+
+- `scripts/upgrade.mjs:137` — default port `3478` → `3456`.
+- `scripts/doctor.mjs:84` — default port `3478` → `3456`.
+- `scripts/doctor.mjs:205` — default port `3478` → `3456`.
+
+No behavior change for users who set `CLAUDE_PROXY_PORT` explicitly; env
+still takes precedence. The fix only affects the unset-env fallback,
+which now matches `server.mjs:126` and the rest of the codebase.
+
+Test plan: existing `test-features.mjs` cases that pin
+`CLAUDE_PROXY_PORT=3478` continue to pass — they use the env path, not
+the default.
+
 ## v3.16.2 — 2026-05-12
 
 ### Fixes — corrects v3.16.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.16.2",
+  "version": "3.16.3",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -81,7 +81,7 @@ export async function runDoctor(opts = {}) {
       health = opts.mockHealth;
     } else {
       try {
-        const port = process.env.CLAUDE_PROXY_PORT || "3478";
+        const port = process.env.CLAUDE_PROXY_PORT || "3456";
         const out = execSync(`curl -sf --max-time 3 http://127.0.0.1:${port}/health`, { stdio: ["pipe", "pipe", "pipe"] }).toString();
         health = { status: 200, body: JSON.parse(out) };
       } catch (e) {
@@ -202,7 +202,7 @@ function runOauthOnly(opts, checks, push) {
     health = opts.mockHealth;
   } else {
     try {
-      const port = process.env.CLAUDE_PROXY_PORT || "3478";
+      const port = process.env.CLAUDE_PROXY_PORT || "3456";
       const out = execSync(`curl -sf --max-time 3 http://127.0.0.1:${port}/health`, { stdio: ["pipe", "pipe", "pipe"] }).toString();
       health = { status: 200, body: JSON.parse(out) };
     } catch (e) {

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -134,7 +134,7 @@ async function runFullUpgrade({ doctor, opts }) {
 
     // phase 6: post-flight (10s budget; skipped under mockExec)
     if (!opts.mockExec) {
-      const port = process.env.CLAUDE_PROXY_PORT || "3478";
+      const port = process.env.CLAUDE_PROXY_PORT || "3456";
       let ok = false;
       for (let i = 0; i < 10; i++) {
         try {


### PR DESCRIPTION
## Summary

Three places in \`scripts/\` still defaulted to \`3478\` after v3.16.2's plugin / manifest / README / plist revert. This PR finishes the revert by aligning these last unset-env defaults with the rest of the codebase (\`server.mjs:126\`).

- \`scripts/upgrade.mjs:137\` — default \`3478\` → \`3456\`
- \`scripts/doctor.mjs:84\` — default \`3478\` → \`3456\`
- \`scripts/doctor.mjs:205\` — default \`3478\` → \`3456\`

## Why

These three lines were the residual cascade source for the port-drift bug originally caused by the PR #71 dogfood accident on 2026-05-08. Every \`ocp doctor\` / \`ocp upgrade\` invocation without an explicit \`CLAUDE_PROXY_PORT\` env probed port 3478 — got \"OCP not responding\" against a healthy 3456 instance — and on the maintainer's host on 2026-05-13 this cascaded into wrong \`baseUrl\` writes for the OpenClaw \`claude-local\` provider, taking out the OpenClaw Telegram agent (\"大内总管\").

v3.16.2 reverted the plugin / manifest / README / plist back to 3456 and corrected the narrative (no port migration ever happened), but missed these three script defaults.

## Impact on users

| User profile | Before | After |
|---|---|---|
| Default install (no env) | \`ocp doctor\` falsely reports \"OCP not responding\" against a healthy 3456 instance | doctor probes 3456, correctly reports status |
| Explicit \`CLAUDE_PROXY_PORT=3456\` | Works (env precedence) | Works (env precedence) |
| Explicit \`CLAUDE_PROXY_PORT=3478\` | Works (env precedence) | Works (env precedence) — unchanged |
| Other custom port via env | Works | Works — unchanged |

No behavior change for any user who sets \`CLAUDE_PROXY_PORT\` explicitly; the env path is the SSOT and is unchanged. Only the unset-env fallback moved, and it now matches \`server.mjs:126\`.

## ALIGNMENT.md note

This is a \`scripts/\` change, not \`server.mjs\`, so the three hard-requirements (\`cli.js\` citation, blacklist CI, independent reviewer) don't strictly apply. But the SPOT spirit does — that's the whole reason this PR exists. CHANGELOG entry under v3.16.3 explains the cascade for the next reviewer.

## Test plan

- [x] \`test-features.mjs\` cases that pin \`CLAUDE_PROXY_PORT=3478\` continue to use env precedence and pass — no behavior change for them.
- [x] Manual verification: \`curl http://127.0.0.1:3456/health\` on maintainer's host returns 200 (server is on 3456; doctor now agrees).
- [ ] On a clean install (next deploy), \`ocp doctor\` after \`ocp install\` reports OCP online without requiring \`CLAUDE_PROXY_PORT\` in env.

## Version

Bumps \`package.json\` to \`v3.16.3\`. CHANGELOG entry added.