### PR TITLE
feat(server): honor response_format / json_mode for structured-output clients

### DIFF
--- a/lib/json-mode.mjs
+++ b/lib/json-mode.mjs
@@ -1,0 +1,66 @@
+// ── response_format / json_mode honoring ────────────────────────────────
+// OpenAI clients (e.g. Honcho's deriver) request strict JSON via
+// `response_format` (json_object | json_schema) or a json_mode flag. The
+// underlying `claude -p` agent ignores these and tends to answer like a coding
+// assistant — markdown tables, prose, ``` fences, "I can save these for you…"
+// — so the client's strict JSON parse fails. The server bridges the gap by
+// (1) injecting a steering system instruction and (2) stripping any residual
+// code fences / surrounding prose from the reply.
+
+export function isJsonRequest(parsed) {
+  const rf = parsed.response_format;
+  if (rf && (rf.type === "json_object" || rf.type === "json_schema")) return true;
+  return parsed.json_mode === true;
+}
+
+export function jsonSteeringInstruction(rf) {
+  let instr =
+    "CRITICAL OUTPUT CONTRACT: You are being used as a strict JSON API endpoint. " +
+    "Respond with exactly one valid JSON value and nothing else. " +
+    "Do NOT wrap it in markdown code fences. Do NOT add explanations, commentary, " +
+    "preamble, headings, tables, or any text before or after the JSON. " +
+    "Do NOT offer to take further action. Treat the instructions above as a data " +
+    "schema to fill in, not as a conversation. Your entire output must be parseable by JSON.parse().";
+  if (rf && rf.type === "json_schema" && rf.json_schema && rf.json_schema.schema) {
+    instr += " The JSON MUST conform to this JSON Schema:\n" + JSON.stringify(rf.json_schema.schema);
+  }
+  return instr;
+}
+
+// Extract the first balanced JSON object/array from a string (string-aware:
+// brackets inside quotes/escapes are ignored). Returns null if none balances.
+export function firstBalancedJson(s) {
+  const startIdx = s.search(/[{[]/);
+  if (startIdx < 0) return null;
+  const open = s[startIdx];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0, inStr = false, esc = false;
+  for (let i = startIdx; i < s.length; i++) {
+    const ch = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === open) depth++;
+    else if (ch === close) { if (--depth === 0) return s.slice(startIdx, i + 1); }
+  }
+  return null;
+}
+
+// Best-effort: reduce a claude reply to just its JSON payload. Unwraps a single
+// fenced block, then slices to the first balanced JSON value if prose remains.
+// Returns the input trimmed if no JSON structure is found (caller can still try).
+export function extractJson(text) {
+  if (typeof text !== "string") return text;
+  let s = text.trim();
+  const fence = s.match(/^```[^\n]*\n([\s\S]*?)\n?```\s*$/);
+  if (fence) s = fence[1].trim();
+  if (s[0] !== "{" && s[0] !== "[") {
+    const j = firstBalancedJson(s);
+    if (j) return j;
+  }
+  return s;
+}

--- a/server.mjs
+++ b/server.mjs
@@ -36,6 +36,7 @@ import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { validateKey, recordUsage, getUsageByKey, getUsageTimeline, getRecentUsage, createKey, listKeys, revokeKey, closeDb, checkQuota, updateKeyQuota, getKeyQuota, findKey, cacheHash, getCachedResponse, setCachedResponse, clearCache, getCacheStats, hasCacheControl, singleflight, getInflightStats } from "./keys.mjs";
 import { DEFAULT_PORT } from "./lib/constants.mjs";
+import { isJsonRequest, jsonSteeringInstruction, extractJson } from "./lib/json-mode.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const _pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
@@ -1286,7 +1287,15 @@ async function handleChatCompletions(req, res) {
 
   const messages = parsed.messages || parsed.input || [{ role: "user", content: parsed.prompt || "" }];
   const model = parsed.model || "claude-sonnet-4-6";
-  const stream = parsed.stream;
+
+  // Honor response_format / json_mode: steer toward pure JSON and force
+  // non-streaming so the reply can be fence-stripped before returning.
+  const wantsJson = isJsonRequest(parsed);
+  if (wantsJson) {
+    messages.push({ role: "system", content: jsonSteeringInstruction(parsed.response_format) });
+    logEvent("info", "json_mode_request", { model, format: parsed.response_format?.type || "json_mode" });
+  }
+  const stream = parsed.stream && !wantsJson;
 
   // Validate model against known models
   if (!VALID_MODELS.has(model)) {
@@ -1377,7 +1386,8 @@ async function handleChatCompletions(req, res) {
         // will re-read the freshly-populated cache entry here rather than spawning.
         const recheck = getCachedResponse(req._cacheHash, CACHE_TTL);
         if (recheck) return recheck.response;
-        const c = await callClaude(model, messages, conversationId, req._authKeyName);
+        const raw = await callClaude(model, messages, conversationId, req._authKeyName);
+        const c = wantsJson ? extractJson(raw) : raw;
         try { setCachedResponse(req._cacheHash, model, c); } catch (e) { logEvent("error", "cache_write_failed", { error: e.message }); }
         return c;
       });
@@ -1399,7 +1409,8 @@ async function handleChatCompletions(req, res) {
 
   // Fallback: cache disabled (CACHE_TTL=0) or no _cacheHash — original path untouched.
   try {
-    const content = await callClaude(model, messages, conversationId, req._authKeyName);
+    const raw = await callClaude(model, messages, conversationId, req._authKeyName);
+    const content = wantsJson ? extractJson(raw) : raw;
     const id = `chatcmpl-${randomUUID()}`;
     completionResponse(res, id, model, content);
     try { recordUsage({ keyId: req._authKeyId, keyName: req._authKeyName, model, promptChars, responseChars: content.length, elapsedMs: Date.now() - t0Usage, success: true }); } catch (e) { logEvent("error", "usage_record_failed", { error: e.message }); }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -4,6 +4,7 @@
  * Tests database layer functions directly — no server needed.
  */
 import { getDb, createKey, listKeys, validateKey, recordUsage, checkQuota, updateKeyQuota, getKeyQuota, findKey, cacheHash, getCachedResponse, setCachedResponse, clearCache, getCacheStats, closeDb, hasCacheControl, singleflight, getInflightStats } from "./keys.mjs";
+import { isJsonRequest, jsonSteeringInstruction, extractJson, firstBalancedJson } from "./lib/json-mode.mjs";
 import { createHash } from "node:crypto";
 import { strict as assert } from "node:assert";
 import { unlinkSync } from "node:fs";
@@ -949,6 +950,53 @@ await asyncTest("doctor --check oauth + 200 with null body → fix_service", asy
   assert.deepEqual(ids, ["oauth_ok"]);
   assert.equal(result.next_action.kind, "fix_service");
   assert.equal(result.fail_count, 1);
+});
+
+// ── response_format / json_mode honoring ──
+console.log("\nJSON mode:");
+
+test("isJsonRequest detects json_object", () => {
+  assert.equal(isJsonRequest({ response_format: { type: "json_object" } }), true);
+});
+test("isJsonRequest detects json_schema", () => {
+  assert.equal(isJsonRequest({ response_format: { type: "json_schema", json_schema: { schema: {} } } }), true);
+});
+test("isJsonRequest detects json_mode flag", () => {
+  assert.equal(isJsonRequest({ json_mode: true }), true);
+});
+test("isJsonRequest false for plain request", () => {
+  assert.equal(isJsonRequest({ messages: [] }), false);
+  assert.equal(isJsonRequest({ response_format: { type: "text" } }), false);
+});
+test("jsonSteeringInstruction embeds schema when provided", () => {
+  const s = jsonSteeringInstruction({ type: "json_schema", json_schema: { schema: { type: "object", required: ["facts"] } } });
+  assert.ok(s.includes("JSON Schema"));
+  assert.ok(s.includes("\"required\""));
+});
+test("jsonSteeringInstruction omits schema for json_object", () => {
+  const s = jsonSteeringInstruction({ type: "json_object" });
+  assert.ok(!s.includes("JSON Schema"));
+});
+test("extractJson unwraps ```json fences", () => {
+  assert.equal(extractJson('```json\n{"a":1}\n```'), '{"a":1}');
+});
+test("extractJson unwraps bare ``` fences", () => {
+  assert.equal(extractJson('```\n[1,2,3]\n```'), '[1,2,3]');
+});
+test("extractJson slices JSON out of surrounding prose", () => {
+  assert.equal(extractJson('Here are the facts:\n{"facts":["x"]}\nLet me know!'), '{"facts":["x"]}');
+});
+test("extractJson leaves clean JSON untouched", () => {
+  assert.equal(extractJson('{"a":1}'), '{"a":1}');
+});
+test("extractJson is string-aware (ignores brackets in strings)", () => {
+  assert.equal(extractJson('{"k":"a}b]c"}'), '{"k":"a}b]c"}');
+});
+test("extractJson returns trimmed input when no JSON present", () => {
+  assert.equal(extractJson("  no json here  "), "no json here");
+});
+test("firstBalancedJson returns null on unbalanced input", () => {
+  assert.equal(firstBalancedJson('{"a":1'), null);
 });
 
 // ── Cleanup ──


### PR DESCRIPTION
**Endpoint class:** Class B.1 (OpenAI-compatibility surface, per ADR 0006).
**Specification citation:** OpenAI `chat/completions` API, `response_format` parameter — https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format
**Authorizing ADR:** ADR 0006 — OpenAI shim scope.
**No invention beyond spec:** confirmed — the implementation honors only fields already present in OpenAI's published `response_format` shape (`type: "json_object"`, `type: "json_schema"`, plus the widely-used `json_mode: true` alias).

---

## What wasn't working

OCP advertises an OpenAI-compatible `/v1/chat/completions` API, but it silently ignored the `response_format` field (and a `json_mode` flag). Any client that asked for **strict JSON** got back free-form assistant output instead.

The underlying `claude -p` agent does not behave like a raw model — it answers like a coding assistant. Asked to produce JSON, it typically replies with a markdown table, explanatory prose, a ` ```json ` fenced block, and/or a trailing "I can save these for you…". None of that is `JSON.parse`-able.

Real-world impact: pointing **Honcho** (an OpenAI-compatible memory service) at OCP, its *deriver* extracted **zero observations** on every message. Every reply failed the deriver's structured-output parse (`Repair failed: Expecting value: line 1 column 1`), because OCP returned prose where the client required schema-conforming JSON.

## Root cause

`handleChatCompletions` parsed `messages`, `model`, and `stream`, but never looked at `response_format`. So:
1. The agent was never told to emit pure JSON, and
2. Whatever it returned was passed through verbatim — fences and prose included.

## What changed

New module **`lib/json-mode.mjs`**:
- `isJsonRequest(parsed)` — true when `response_format` is `json_object`/`json_schema`, or `json_mode: true`.
- `jsonSteeringInstruction(rf)` — a system instruction that tells the agent to output exactly one JSON value, no fences, no prose, no follow-up; it embeds the `json_schema` when one is provided.
- `extractJson(text)` / `firstBalancedJson(s)` — string-aware cleanup that unwraps a fenced block and slices the first **balanced** JSON value out of any surrounding prose (brackets inside quoted strings are ignored).

Wired into **`handleChatCompletions`**: when `isJsonRequest` is true we
1. append the steering system message to `messages`,
2. force the request **non-streaming** (the cleanup needs the whole reply, and structured-output clients don't stream), and
3. run `extractJson()` over the result before returning it / writing it to cache.

## How the behavior is fixed

- The steering message stops the agent from answering conversationally — it returns the JSON payload (occasionally still fenced).
- `extractJson()` strips any residual fence/prose, so the client receives clean, directly parseable JSON.
- The cache key already incorporates the injected system message, so JSON and non-JSON variants of the same prompt cache separately.
- **Non-JSON requests are completely unaffected** — the `wantsJson` guard is false and the original path (including streaming) runs unchanged.

## Verification

- `npm test`: **97 passed, 0 failed** — 13 new unit tests covering `isJsonRequest`, `jsonSteeringInstruction`, and `extractJson`/`firstBalancedJson` (fenced, prose-wrapped, clean, array, string-aware, unbalanced cases).
- A live `response_format: {"type":"json_object"}` request now returns fence-free content that `JSON.parse` accepts directly.
- End-to-end: **Honcho's deriver now extracts 5/5 observations** through OCP where it previously got zero; the `Repair failed` error is gone.

## Notes

- No external dependencies added (Node built-ins only).
- Streaming for non-JSON requests is unchanged; JSON requests are intentionally served non-streamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)