### PR TITLE
feat(tui-mode): route requests through Claude interactive TUI to avoid Agent SDK billing

### DIFF
--- a/.claude/hooks/inject-json-contract.sh
+++ b/.claude/hooks/inject-json-contract.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: inject result.json output contract for all OCP TUI requests.
+# OCP_JSON_MODE=1: write structured JSON (schema from schema.json if present)
+# OCP_JSON_MODE=0: write plain text wrapped as {"content":"..."}
+set -euo pipefail
+
+# Only inject for OCP TUI sessions (OCP_RESULT_DIR must be set)
+[ -n "${OCP_RESULT_DIR:-}" ] || exit 0
+
+INPUT=$(cat)
+RESULT_FILE="${OCP_RESULT_DIR}/result.json"
+SCHEMA_FILE="${OCP_RESULT_DIR}/schema.json"
+
+if [ "${OCP_JSON_MODE:-0}" = "1" ]; then
+  SCHEMA_CLAUSE=""
+  if [ -f "$SCHEMA_FILE" ]; then
+    SCHEMA_CLAUSE="\nThe JSON MUST conform to this JSON Schema: $(cat $SCHEMA_FILE)"
+  fi
+
+  printf '\n---\n[JSON OUTPUT CONTRACT - enforced by Stop Hook]\nWrite the structured JSON value to: %s%b\nDo NOT print the JSON payload in chat.\nAfter writing validate with: jq -e . %s\nYour ONLY chat response must be exactly:\n{"status":"success","result_file":"%s"}\n[END CONTRACT]\n---\n'     "$RESULT_FILE" "$SCHEMA_CLAUSE" "$RESULT_FILE" "$RESULT_FILE"
+else
+  printf '\n---\n[RESPONSE CAPTURE CONTRACT - enforced by Stop Hook]\nWrite your complete response as JSON to: %s\nFormat: {"content": "your full response here"}\nEscape special characters properly so the file is valid JSON.\nDo NOT print the response in chat.\nYour ONLY chat response must be exactly:\n{"status":"success","result_file":"%s"}\n[END CONTRACT]\n---\n'     "$RESULT_FILE" "$RESULT_FILE"
+fi

--- a/.claude/hooks/validate-json-output.sh
+++ b/.claude/hooks/validate-json-output.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Stop hook: block until result.json is valid JSON — for all OCP TUI sessions.
+set -euo pipefail
+
+# Only enforce for OCP TUI sessions (OCP_RESULT_DIR must be set)
+[ -n "${OCP_RESULT_DIR:-}" ] || exit 0
+
+RESULT="${OCP_RESULT_DIR}/result.json"
+
+if [ ! -f "$RESULT" ]; then
+  printf '{"decision":"block","reason":"Write response to %s first."}' "$RESULT"
+  exit 0
+fi
+
+if ! jq -e . "$RESULT" >/dev/null 2>&1; then
+  printf '{"decision":"block","reason":"%s is not valid JSON. Fix it."}' "$RESULT"
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/ocp/.claude/hooks/inject-json-contract.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/ocp/.claude/hooks/validate-json-output.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/lib/tmux-session.mjs
+++ b/lib/tmux-session.mjs
@@ -1,0 +1,184 @@
+// lib/tmux-session.mjs
+// Runs Claude Code in interactive TUI mode via a tmux session.
+//
+// Why not `claude -p`?
+// Anthropic's 2026-06-15 billing change moves `claude -p` (non-interactive /
+// Agent SDK usage) into a separate credit pool with a hard monthly cap. The
+// interactive TUI mode stays within the normal subscription.  By routing OCP
+// requests through a tmux-hosted TUI session we stay on the subscription path
+// while retaining full tool access and the hook-enforced JSON contract.
+//
+// JSON contract enforcement (see .claude/hooks/):
+//   UserPromptSubmit  — injects the output-contract instruction into every prompt.
+//   Stop              — blocks the session from stopping until result.json exists
+//                       and passes `jq -e`.  Claude is forced to fix any invalid
+//                       output before the session can end.
+
+import { randomUUID }          from "node:crypto";
+import { execFileSync }        from "node:child_process";
+import { mkdirSync, existsSync,
+         readFileSync, rmSync,
+         writeFileSync }       from "node:fs";
+import { fileURLToPath }       from "node:url";
+import { dirname, join }       from "node:path";
+
+const __dir   = dirname(fileURLToPath(import.meta.url));
+const OCP_CWD = join(__dir, ".."); // /opt/ocp
+
+const CLAUDE_BIN      = process.env.CLAUDE_BIN || "/usr/local/bin/claude";
+const POLL_MS         = 300;
+const READY_TIMEOUT   = 15_000;
+const TMUX_WIDTH      = "220";
+const TMUX_HEIGHT     = "50";
+// Max concurrent TUI sessions — each holds a tmux pane + claude process.
+const MAX_TUI_SESSIONS = parseInt(process.env.CLAUDE_MAX_TUI || "4", 10);
+let _activeSessions = 0;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function tmuxSync(...args) {
+  return execFileSync("tmux", args, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// ── session ready detection ────────────────────────────────────────────────
+// Poll until the ❯ prompt is visible and no dialog is blocking.
+
+async function waitForReady(sname) {
+  const deadline = Date.now() + READY_TIMEOUT;
+  while (Date.now() < deadline) {
+    let pane = "";
+    try { pane = tmuxSync("capture-pane", "-t", sname, "-p"); } catch { /* session still starting */ }
+
+    // Auto-dismiss workspace trust dialog ("Is this a project you trust?")
+    if (pane.includes("Is this a project") || pane.includes("Yes, I trust this folder")) {
+      try { tmuxSync("send-keys", "-t", sname, "1", "Enter"); } catch {}
+      await sleep(500);
+      continue;
+    }
+
+    // Auto-dismiss tool-use permission dialogs ("Do you want to create/edit/run...")
+    if (pane.includes("Do you want to") && pane.includes("1. Yes")) {
+      try { tmuxSync("send-keys", "-t", sname, "1", "Enter"); } catch {}
+      await sleep(300);
+      continue;
+    }
+
+    if (pane.includes("❯")) return;
+    await sleep(300);
+  }
+  throw new Error(`Claude TUI not ready after ${READY_TIMEOUT}ms (session: ${sname})`);
+}
+
+// ── result file polling ────────────────────────────────────────────────────
+
+async function waitForResult(resultFile, timeoutMs, jsonMode) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(resultFile)) {
+      const raw = readFileSync(resultFile, "utf8").trim();
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          // json mode: result.json IS the JSON value — return raw string
+          // non-json mode: result.json = {"content":"..."} — extract the text
+          if (!jsonMode && typeof parsed === "object" && parsed !== null && "content" in parsed) {
+            return String(parsed.content);
+          }
+          return raw;
+        } catch { /* written but incomplete — keep polling */ }
+      }
+    }
+    await sleep(POLL_MS);
+  }
+  throw new Error(`result.json not ready within ${timeoutMs}ms: ${resultFile}`);
+}
+
+// ── public API ─────────────────────────────────────────────────────────────
+
+/**
+ * callClaudeTui(prompt, options)
+ *
+ * Runs Claude Code in interactive TUI mode inside a dedicated tmux session.
+ * Returns the contents of result.json as a string (valid JSON guaranteed by
+ * the Stop hook contract).
+ *
+ * @param {string} prompt       — the full text prompt to send
+ * @param {object} options
+ *   @param {string} model      — Claude model identifier
+ *   @param {number} timeoutMs  — per-request timeout (default: 120 000 ms)
+ *   @param {string} systemPrompt
+ *   @param {boolean} noContext — suppress CLAUDE.md / auto-memory injection
+ */
+export async function callClaudeTui(prompt, {
+  model       = "claude-haiku-4-5-20251001",
+  timeoutMs   = 120_000,
+  systemPrompt = "",
+  noContext   = true,
+  jsonMode    = false,   // true → OCP_JSON_MODE=1 in session; hooks enforce result.json
+  schema      = null,    // JSON Schema object for json_mode; written to resultDir/schema.json
+} = {}) {
+  if (_activeSessions >= MAX_TUI_SESSIONS) {
+    throw new Error(`TUI session limit reached (${_activeSessions}/${MAX_TUI_SESSIONS}). ` +
+      "Increase CLAUDE_MAX_TUI or wait for a session to finish.");
+  }
+
+  const requestId  = randomUUID();
+  const sname      = `ocp-${requestId.slice(0, 12)}`;
+  const resultDir  = `/tmp/ocp-sessions/${requestId}`;
+  const resultFile = `${resultDir}/result.json`;
+  const wrapScript = `${resultDir}/start.sh`;
+
+  mkdirSync(resultDir, { recursive: true });
+
+  // Write schema.json so the inject hook can include it in the contract
+  if (jsonMode && schema) {
+    writeFileSync(`${resultDir}/schema.json`, JSON.stringify(schema));
+  }
+
+  // Per-request env (written into a wrapper script to avoid tmux quoting hell).
+  // Each request gets a unique resultDir so concurrent sessions never share files.
+  const envLines = [
+    `export OCP_RESULT_DIR="${resultDir}"`,
+    `export OCP_RESULT_FILE="${resultFile}"`,
+    jsonMode ? 'export OCP_JSON_MODE="1"' : 'export OCP_JSON_MODE="0"',
+    noContext ? 'export CLAUDE_CODE_DISABLE_CLAUDE_MDS="1"'  : "",
+    noContext ? 'export CLAUDE_CODE_DISABLE_AUTO_MEMORY="1"' : "",
+    // Strip API key vars — force OAuth path, same as current OCP behaviour
+    "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN CLAUDECODE",
+  ].filter(Boolean).join("\n");
+
+  const claudeArgs = [
+    "--dangerously-skip-permissions",
+    "--model", model,
+    ...(systemPrompt ? ["--append-system-prompt", systemPrompt] : []),
+  ].join(" ");
+
+  writeFileSync(wrapScript,
+    `#!/usr/bin/env bash\n${envLines}\nexec "${CLAUDE_BIN}" ${claudeArgs}\n`,
+    { mode: 0o700 });
+
+  _activeSessions++;
+  try {
+    // Spawn the TUI session — each has unique sname/resultDir so concurrent requests
+    // never interfere with each other.
+    tmuxSync("new-session", "-d", "-s", sname,
+      "-x", TMUX_WIDTH, "-y", TMUX_HEIGHT,
+      "-c", OCP_CWD,
+      "--", "bash", wrapScript);
+
+    await waitForReady(sname);
+
+    // Deliver the prompt
+    tmuxSync("send-keys", "-t", sname, prompt, "Enter");
+
+    // Wait for the hook-validated result file
+    return await waitForResult(resultFile, timeoutMs, jsonMode);
+
+  } finally {
+    _activeSessions--;
+    try { tmuxSync("kill-session", "-t", sname); } catch {}
+    try { rmSync(resultDir, { recursive: true, force: true }); } catch {}
+  }
+}

--- a/server.mjs
+++ b/server.mjs
@@ -2,8 +2,12 @@
 /**
  * openclaw-claude-proxy — OpenAI-compatible proxy for Claude CLI
  *
- * Translates OpenAI chat/completions requests into `claude -p` CLI calls,
- * letting you use your Claude Pro/Max subscription as an OpenClaw model provider.
+ * Translates OpenAI chat/completions requests into Claude calls.
+ * Supports two execution modes (CLAUDE_TUI_MODE env var):
+ *   false (default) — spawns `claude -p` per request (fast, uses Agent SDK credits)
+ *   true            — runs Claude in interactive TUI mode via tmux; stays within the
+ *                     subscription (avoids the Agent SDK credit pool introduced in the
+ *                     Anthropic 2026-06-15 billing change).
  *
  * Timeout design: single CLAUDE_TIMEOUT (default 600s / 10 min).
  * No separate first-byte or idle timeout — Claude tool-use causes long pauses
@@ -36,6 +40,7 @@ import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { validateKey, recordUsage, getUsageByKey, getUsageTimeline, getRecentUsage, createKey, listKeys, revokeKey, closeDb, checkQuota, updateKeyQuota, getKeyQuota, findKey, cacheHash, getCachedResponse, setCachedResponse, clearCache, getCacheStats, hasCacheControl, singleflight, getInflightStats } from "./keys.mjs";
 import { DEFAULT_PORT } from "./lib/constants.mjs";
+import { callClaudeTui } from "./lib/tmux-session.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const _pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"));
@@ -142,7 +147,9 @@ const BREAKER_WINDOW = parseInt(process.env.CLAUDE_BREAKER_WINDOW || "300000", 1
 const BREAKER_HALF_OPEN_MAX = parseInt(process.env.CLAUDE_BREAKER_HALF_OPEN_MAX || "2", 10);
 const HEARTBEAT_INTERVAL = parseInt(process.env.CLAUDE_HEARTBEAT_INTERVAL || "0", 10);
 const BIND_ADDRESS = process.env.CLAUDE_BIND || "127.0.0.1";
-const NO_CONTEXT = process.env.CLAUDE_NO_CONTEXT === "true";
+const NO_CONTEXT  = process.env.CLAUDE_NO_CONTEXT  === "true";
+// CLAUDE_TUI_MODE=true: route all requests through interactive TUI (no Agent SDK credits).
+const TUI_MODE    = process.env.CLAUDE_TUI_MODE    === "true";
 const AUTH_MODE = process.env.CLAUDE_AUTH_MODE || (PROXY_API_KEY ? "shared" : "none");
 const ADMIN_KEY = process.env.OCP_ADMIN_KEY || "";
 const PROXY_ANONYMOUS_KEY = process.env.PROXY_ANONYMOUS_KEY || "";
@@ -411,6 +418,32 @@ function buildCliArgs(cliModel, sessionInfo) {
   }
 
   return args;
+}
+
+
+// ── JSON mode helpers for TUI path ─────────────────────────────────────────
+function tuiSchema(parsed) {
+  const rf = parsed.response_format;
+  if (rf && rf.type === "json_schema" && rf.json_schema && rf.json_schema.schema) return rf.json_schema.schema;
+  return null;
+}
+
+function isJsonRequest(parsed) {
+  const rf = parsed.response_format;
+  if (rf && (rf.type === "json_object" || rf.type === "json_schema")) return true;
+  return parsed.json_mode === true;
+}
+
+function jsonSteeringText(parsed) {
+  const rf = parsed.response_format;
+  let instr = "OUTPUT CONTRACT: Respond with exactly one valid JSON value. " +
+    "No markdown fences, no prose, no explanations before or after. " +
+    "Your entire response must be parseable by JSON.parse().";
+  if (rf && rf.type === "json_schema" && rf.json_schema && rf.json_schema.schema) {
+    instr += " The JSON MUST conform to this JSON Schema: " +
+      JSON.stringify(rf.json_schema.schema);
+  }
+  return instr;
 }
 
 // ── Format messages to prompt text ──────────────────────────────────────
@@ -1358,6 +1391,29 @@ async function handleChatCompletions(req, res) {
 
   if (stream) {
     // Real streaming: pipe stdout from claude process directly as SSE chunks
+    if (TUI_MODE) {
+      // TUI mode: collect full result, then replay as SSE chunks (subscription billing)
+      const tuiPrompt = messagesToPrompt(messages);
+      let tuiContent;
+      try {
+        tuiContent = await callClaudeTui(tuiPrompt, { model, timeoutMs: TIMEOUT, systemPrompt: SYSTEM_PROMPT, noContext: NO_CONTEXT, jsonMode: isJsonRequest(parsed), schema: tuiSchema(parsed) });
+      } catch (err) {
+        logEvent("error", "tui_error", { model, error: err.message });
+        if (!res.headersSent) return jsonResponse(res, 500, { error: { message: err.message.replace(/\/[\w/.\-]+/g, "[path]"), type: "proxy_error" } });
+        return;
+      }
+      // Replay as SSE stream
+      const id = `chatcmpl-${randomUUID()}`;
+      const created = Math.floor(Date.now() / 1000);
+      const CHUNK = 80;
+      res.writeHead(200, { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", "Connection": "keep-alive" });
+      sendSSE(res, { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] });
+      const pts = Array.from(tuiContent);
+      for (let i = 0; i < pts.length; i += CHUNK) sendSSE(res, { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { content: pts.slice(i, i + CHUNK).join("") }, finish_reason: null }] });
+      sendSSE(res, { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] });
+      res.write("data: [DONE]\n\n"); res.end();
+      return;
+    }
     return callClaudeStreaming(model, messages, conversationId, res, { keyId: req._authKeyId, keyName: req._authKeyName, cacheHash: req._cacheHash });
   }
 
@@ -1377,7 +1433,9 @@ async function handleChatCompletions(req, res) {
         // will re-read the freshly-populated cache entry here rather than spawning.
         const recheck = getCachedResponse(req._cacheHash, CACHE_TTL);
         if (recheck) return recheck.response;
-        const c = await callClaude(model, messages, conversationId, req._authKeyName);
+        const c = TUI_MODE
+          ? await callClaudeTui(messagesToPrompt(messages), { model, timeoutMs: TIMEOUT, systemPrompt: SYSTEM_PROMPT, noContext: NO_CONTEXT, jsonMode: isJsonRequest(parsed), schema: tuiSchema(parsed) })
+          : await callClaude(model, messages, conversationId, req._authKeyName);
         try { setCachedResponse(req._cacheHash, model, c); } catch (e) { logEvent("error", "cache_write_failed", { error: e.message }); }
         return c;
       });
@@ -1399,7 +1457,9 @@ async function handleChatCompletions(req, res) {
 
   // Fallback: cache disabled (CACHE_TTL=0) or no _cacheHash — original path untouched.
   try {
-    const content = await callClaude(model, messages, conversationId, req._authKeyName);
+    const content = TUI_MODE
+      ? await callClaudeTui(messagesToPrompt(messages), { model, timeoutMs: TIMEOUT, systemPrompt: SYSTEM_PROMPT, noContext: NO_CONTEXT, jsonMode: isJsonRequest(parsed), schema: tuiSchema(parsed) })
+      : await callClaude(model, messages, conversationId, req._authKeyName);
     const id = `chatcmpl-${randomUUID()}`;
     completionResponse(res, id, model, content);
     try { recordUsage({ keyId: req._authKeyId, keyName: req._authKeyName, model, promptChars, responseChars: content.length, elapsedMs: Date.now() - t0Usage, success: true }); } catch (e) { logEvent("error", "usage_record_failed", { error: e.message }); }


### PR DESCRIPTION
## Summary

- **Motivation**: Anthropic's 2026-06-15 billing change moves `claude -p` (non-interactive / Agent SDK usage) into a separate monthly credit pool with a hard cap. Interactive Claude Code TUI sessions remain on the standard subscription. This PR routes OCP requests through a tmux-hosted TUI session to stay on the subscription path.
- **New `lib/tmux-session.mjs`**: spawns a per-request tmux session using a UUID-based session name and isolated result directory. Polls for `result.json` written by Claude under hook contract. Auto-dismisses workspace trust and tool-permission dialogs.
- **Hook contract (`.claude/hooks/`)**: `UserPromptSubmit` injects a file-writing contract (with JSON Schema if `response_format.json_schema` is present); `Stop` hook validates `result.json` with `jq -e` before allowing the session to end — guaranteeing valid output.
- **`server.mjs`**: `CLAUDE_TUI_MODE=true` env var switches all three request paths (streaming replay, singleflight, fallback) to `callClaudeTui`. Non-TUI path is completely unchanged.

## Concurrent-request safety

Each request gets a unique `sname=ocp-{uuid-slice}` and `resultDir=/tmp/ocp-sessions/{uuid}/` so sessions never share files or race on result.json. An `_activeSessions` counter with `CLAUDE_MAX_TUI` (default 4, overridable via env) limits resource usage.

## Test plan

- [x] Non-json plain text request returns text response
- [x] `json_schema` request returns schema-conformant JSON (tested with Honcho deriver pattern)
- [x] 2 concurrent requests complete without interference
- [ ] Streaming SSE replay path
- [ ] Graceful error when TUI session limit exceeded

## Activation

```bash
CLAUDE_TUI_MODE=true node server.mjs
CLAUDE_MAX_TUI=8 CLAUDE_TUI_MODE=true node server.mjs
```

Generated with [Claude Code](https://claude.ai/code)
