### PR TITLE
chore(release): v3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v3.17.0 — 2026-05-31
+
+### Provider — default claude invocation ported to stream-json + `--system-prompt` (Phase 6c)
+
+OCP's default (non-TUI) claude spawn moves from `claude -p --output-format text` to `claude --output-format stream-json --verbose --no-session-persistence --system-prompt <wrapper>` (no `-p`). The NDJSON event stream is parsed into the assembled response. Benefits: ~64% per-request cost reduction and anti-hallucination via `--system-prompt` tool-use suppression. Clients see no API change — the OpenAI-compatible request/response shapes are identical. Faithful port of OLP's production-verified implementation; covered by 17 new stream-json parser tests.
+
+⚠️ **Billing note:** from 2026-06-15 this default path carries `cc_entrypoint=sdk-cli` and bills against the Agent SDK credit pool. Use the new opt-in `CLAUDE_TUI_MODE` (below) to keep traffic on the Pro/Max subscription pool.
+
+---
+
 ### feat(tui): opt-in CLAUDE_TUI_MODE — serve via interactive claude (cc_entrypoint=cli / subscription pool), single-user only; default stream-json path unchanged
 
 From 2026-06-15 Anthropic routes `claude -p` / `--output-format` invocations to the Agent SDK credit pool (`cc_entrypoint=sdk-cli`). This feature adds an opt-in bridge: when `CLAUDE_TUI_MODE=true`, OCP serves each request via a real interactive `claude` session (no `-p`, no `--output-format`) so it carries `cc_entrypoint=cli` and bills against the Pro/Max subscription.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.16.4",
+  "version": "3.17.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps `package.json` 3.16.4 → **3.17.0** and promotes the CHANGELOG `Unreleased` section.

### What ships in v3.17.0 (already merged to main)
- **Phase 6c (#103):** default claude spawn ported `claude -p text` → `claude --output-format stream-json --verbose --no-session-persistence --system-prompt` (~64% per-request cost cut + anti-hallucination). OpenAI-compat contract unchanged. ⚠️ post-2026-06-15 this default carries `cc_entrypoint=sdk-cli` (Agent SDK credit pool) — use TUI-mode below to stay on subscription.
- **opus 4.8 (#103):** `claude-opus-4-8` added; `aliases.opus` repointed.
- **TUI-mode (#104):** opt-in `CLAUDE_TUI_MODE` — serves via interactive claude (`cc_entrypoint=cli` → Pro/Max subscription pool), reading from the native JSONL transcript. Default-off; default stream-json path byte-identical when unset. Single-user only (see ADR 0007). 5 independent reviews, e2e-green.
- **Sandbox strategy doc (#102):** forward-looking B-path multi-tenant isolation plan.

### Semver
Minor (3.17.0): all changes are additive / opt-in; no breaking change to the OpenAI-compatible API.

### Release
`node test-features.mjs` → **136/0**. Merging this + tagging `v3.17.0` triggers `.github/workflows/release.yml` to auto-create the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)