### PR TITLE
fix: record OAuth-host verification + models.json SPOT (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fix
+
+- **#112** — Recorded OAuth-host verification against compiled cli.js v2.1.154 (ALIGNMENT Class A); usage-probe and default request model now derive from `models.json` (ADR 0003 SPOT) instead of hardcoded IDs.
+
 ### Security
 
 - **#109 P0** — `/health` no longer advertises `PROXY_ANONYMOUS_KEY` to remote callers by default. The `anonymousKey` field is now gated behind a new `PROXY_ADVERTISE_ANON_KEY=1` opt-in env var; localhost callers are always exempt. This prevents any LAN-reachable device from harvesting a working bearer credential from the unauthenticated `/health` endpoint.

--- a/server.mjs
+++ b/server.mjs
@@ -1222,6 +1222,12 @@ function streamStringAsSSE(res, id, model, content) {
 
 let usageCache = { data: null, fetchedAt: 0 };
 const USAGE_CACHE_TTL = 5 * 60 * 1000; // 5 min
+// ALIGNMENT (Class A — OAuth bearer machinery). Verified against the compiled cli.js
+// (claude.exe v2.1.154) on 2026-05-31 via `strings`: both OAUTH_CLIENT_ID and
+// OAUTH_TOKEN_URL appear in the binary byte-for-byte; the legacy host
+// console.anthropic.com/v1/oauth is absent (0 hits). Re-verify on cli.js major bumps
+// using the compiled-binary protocol (strings on the Mach-O/ELF; no live OAuth probe —
+// a refresh-token grant would rotate the operator's real credentials). (issue #112)
 const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
 
@@ -1329,7 +1335,7 @@ async function fetchUsageFromApi() {
   // Minimal /v1/messages request — we only need the response headers.
   // Mirrors Claude Code cli.js vE4: headers anthropic-ratelimit-unified-{5h,7d}-{utilization,reset}.
   const body = JSON.stringify({
-    model: "claude-haiku-4-5-20251001",
+    model: modelsConfig.aliases.haiku,
     max_tokens: 1,
     messages: [{ role: "user", content: "." }],
   });
@@ -1670,7 +1676,7 @@ async function handleChatCompletions(req, res) {
   try { parsed = JSON.parse(body); } catch { return jsonResponse(res, 400, { error: "Invalid JSON" }); }
 
   const messages = parsed.messages || parsed.input || [{ role: "user", content: parsed.prompt || "" }];
-  const model = parsed.model || "claude-sonnet-4-6";
+  const model = parsed.model || modelsConfig.aliases.sonnet;
   const stream = parsed.stream;
 
   // Validate model against known models

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1654,6 +1654,27 @@ test("sanitizeError: multiple paths all stripped", () => {
   assert.ok(result.includes("[path]"), `expected [path] in: ${result}`);
 });
 
+// ── models.json SPOT wiring (issue #112) ────────────────────────────────────
+// Asserts that the alias values used by server.mjs (usage probe + default model)
+// match the expected IDs. A future alias rename that silently breaks these
+// code paths is caught here.
+import { readFileSync as spotReadFileSync } from "node:fs";
+import { fileURLToPath as spotFileURLToPath } from "node:url";
+import { dirname as spotDirname, join as spotJoin } from "node:path";
+
+console.log("\nmodels.json SPOT aliases (issue #112):");
+
+const _spotDir = spotDirname(spotFileURLToPath(import.meta.url));
+const _spotModels = JSON.parse(spotReadFileSync(spotJoin(_spotDir, "models.json"), "utf8"));
+
+test("models.json aliases.haiku === 'claude-haiku-4-5-20251001' (usage-probe SPOT)", () => {
+  assert.equal(_spotModels.aliases.haiku, "claude-haiku-4-5-20251001");
+});
+
+test("models.json aliases.sonnet === 'claude-sonnet-4-6' (default-request-model SPOT)", () => {
+  assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-4-6");
+});
+
 // ── Cleanup ──
 closeDb();
 


### PR DESCRIPTION
## Summary
Fixes the three alignment / `models.json`-SPOT findings from the 2026-05-31 audit (#112, 2×P2 + 1×P3).

1. **OAuth-host verification recorded** — `OAUTH_TOKEN_URL = platform.claude.com/v1/oauth/token` (a Class A surface) was born in the 2026-04-11 drift commit with no verification record. **Verified against the compiled cli.js** (`claude.exe` v2.1.154) via `strings`: `OAUTH_TOKEN_URL` and `OAUTH_CLIENT_ID` both present byte-for-byte (paired in the binary's `prod` config object); legacy `console.anthropic.com/v1/oauth` absent (0 hits). Recorded as an inline ALIGNMENT citation comment. No live OAuth probe (would rotate the operator's real refresh token).
2. **Usage probe SPOT** — `fetchUsageFromApi()` now uses `modelsConfig.aliases.haiku` instead of a hardcoded ID (ADR 0003).
3. **[P3] Default model SPOT** — default request model now `modelsConfig.aliases.sonnet`.

Both SPOT values are byte-identical to the literals they replace today → zero behavior change, only drift-resistance.

**Deliberately deferred:** the `alignment.yml` blacklist pin for the wrong-host variant. Extending the CI blacklist is a governance-layer change (per alignment.yml's own inline "extend only via an ALIGNMENT.md amendment PR" policy) and belongs in its own constitutional PR — not smuggled into a code-fix PR.

## ALIGNMENT.md (server.mjs hard requirements)
1. **cli.js citation:** finding 1 **is** the citation — `platform.claude.com/v1/oauth/token` + client_id verified against compiled `claude.exe` v2.1.154 (2026-05-31). Findings 2-3 forward no new operation (SPOT hygiene).
2. **CI blacklist:** no blacklisted tokens / port literals introduced; `alignment.yml` passes (and is untouched).
3. **Independent reviewer (Iron Rule 10 + alignment hard-req #3):** a fresh-context opus reviewer **independently re-ran `strings`** on the binary and confirmed the host present (×2), client_id present (×2), and the legacy host absent (×0) — not trusting the diff's comment. Confirmed `modelsConfig` in scope, both aliases resolve to current `VALID_MODELS` members (no 400 risk), `alignment.yml` untouched. `npm test` → **154 passed, 0 failed**. Verdict **APPROVE**.

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
