### PR TITLE
fix: escape dashboard DB-sourced values + validate key names (#114)

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -132,6 +132,10 @@ function fmtChars(n) {
   return n > 1000 ? (n/1000).toFixed(0) + "K" : String(n);
 }
 
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
 function barColor(pct) {
   if (pct >= 80) return "bar-red";
   if (pct >= 50) return "bar-amber";
@@ -181,21 +185,21 @@ async function refreshUsage() {
     const tbody = document.querySelector("#key-usage-table tbody");
     tbody.innerHTML = (data.byKey || []).map(k => `
       <tr>
-        <td>${k.key_name}</td>
+        <td>${escapeHtml(k.key_name)}</td>
         <td>${k.requests}</td>
         <td>${k.successes}</td>
         <td>${k.errors}</td>
         <td>${fmtTime(k.avg_elapsed_ms)}</td>
-        <td class="mono">${k.last_request || '-'}</td>
+        <td class="mono">${escapeHtml(k.last_request || '-')}</td>
       </tr>
     `).join("") || '<tr><td colspan="6" style="color:#475569">No usage data yet</td></tr>';
 
     const rtbody = document.querySelector("#recent-table tbody");
     rtbody.innerHTML = (data.recent || []).slice(0, 20).map(r => `
       <tr>
-        <td class="mono">${r.created_at?.slice(11, 19) || '?'}</td>
-        <td>${r.key_name}</td>
-        <td>${r.model}</td>
+        <td class="mono">${escapeHtml(r.created_at?.slice(11, 19) || '?')}</td>
+        <td>${escapeHtml(r.key_name)}</td>
+        <td>${escapeHtml(r.model)}</td>
         <td>${fmtChars(r.prompt_chars)}</td>
         <td>${fmtChars(r.response_chars)}</td>
         <td>${fmtTime(r.elapsed_ms)}</td>
@@ -216,13 +220,16 @@ async function refreshKeys() {
     const tbody = document.querySelector("#keys-table tbody");
     tbody.innerHTML = (data.keys || []).map(k => `
       <tr>
-        <td>${k.name}</td>
-        <td class="mono">${k.keyPreview}</td>
-        <td class="mono">${k.created_at}</td>
+        <td>${escapeHtml(k.name)}</td>
+        <td class="mono">${escapeHtml(k.keyPreview)}</td>
+        <td class="mono">${escapeHtml(k.created_at)}</td>
         <td><span class="tag ${k.revoked ? 'tag-err' : 'tag-ok'}">${k.revoked ? 'revoked' : 'active'}</span></td>
-        <td>${k.revoked ? '' : `<button class="btn btn-sm btn-danger" onclick="revokeKeyUI('${k.name}')">Revoke</button>`}</td>
+        <td>${k.revoked ? '' : `<button class="btn btn-sm btn-danger" data-revoke="${escapeHtml(k.name)}">Revoke</button>`}</td>
       </tr>
     `).join("");
+    tbody.querySelectorAll("button[data-revoke]").forEach(btn =>
+      btn.addEventListener("click", () => revokeKeyUI(btn.getAttribute("data-revoke")))
+    );
   } catch(e) { /* not admin */ }
 }
 

--- a/server.mjs
+++ b/server.mjs
@@ -2048,6 +2048,9 @@ const server = createServer(async (req, res) => {
     let parsed;
     try { parsed = JSON.parse(body); } catch { return jsonResponse(res, 400, { error: "Invalid JSON" }); }
     const name = parsed.name || `key-${Date.now()}`;
+    if (!/^[A-Za-z0-9 ._-]{1,64}$/.test(name)) {
+      return jsonResponse(res, 400, { error: { message: "Invalid key name: 1-64 chars of letters, digits, space, dot, underscore, hyphen", type: "invalid_request_error" } });
+    }
     const newKey = createKey(name);
     return jsonResponse(res, 201, newKey);
   }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1743,6 +1743,55 @@ test("models.json aliases.sonnet === 'claude-sonnet-4-6' (default-request-model 
   assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-4-6");
 });
 
+// ── escapeHtml + key-name validator (issue #114) ────────────────────────────
+// Replicated verbatim from dashboard.html so tests run without a browser.
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+const KEY_NAME_RE = /^[A-Za-z0-9 ._-]{1,64}$/;
+
+console.log("\nescapeHtml (issue #114):");
+
+test("escapeHtml: XSS payload → &lt;img not <img", () => {
+  const out = escapeHtml('<img src=x onerror=alert(1)>');
+  assert.ok(out.includes("&lt;img"), `expected &lt;img in: ${out}`);
+  assert.ok(!out.includes("<img"), `expected no raw <img in: ${out}`);
+});
+
+test("escapeHtml: single-quote, double-quote, ampersand all escaped", () => {
+  assert.equal(escapeHtml("a'b\"c&d"), "a&#39;b&quot;c&amp;d");
+});
+
+test("escapeHtml: null → empty string", () => {
+  assert.equal(escapeHtml(null), "");
+});
+
+console.log("\nKey-name validator (issue #114):");
+
+test("KEY_NAME_RE: 'wife-laptop' → valid", () => {
+  assert.ok(KEY_NAME_RE.test("wife-laptop"));
+});
+
+test("KEY_NAME_RE: 'key-1700000000000' → valid", () => {
+  assert.ok(KEY_NAME_RE.test("key-1700000000000"));
+});
+
+test("KEY_NAME_RE: '<script>' → invalid", () => {
+  assert.ok(!KEY_NAME_RE.test("<script>"));
+});
+
+test("KEY_NAME_RE: \"a'); DROP\" → invalid", () => {
+  assert.ok(!KEY_NAME_RE.test("a'); DROP"));
+});
+
+test("KEY_NAME_RE: empty string → invalid", () => {
+  assert.ok(!KEY_NAME_RE.test(""));
+});
+
+test("KEY_NAME_RE: 65-char string → invalid", () => {
+  assert.ok(!KEY_NAME_RE.test("x".repeat(65)));
+});
+
 // ── Cleanup ──
 closeDb();
 


### PR DESCRIPTION
## Summary
Fixes the dashboard stored-XSS / unescaped-sink finding from the 2026-05-31 audit (#114, P2).

- **dashboard.html** — added `escapeHtml()`; applied it to every DB/string-sourced interpolation in `refreshUsage` + `refreshKeys` (`key_name`, `name`, `keyPreview`, `created_at`, `last_request`, `model`). Replaced the inline `onclick="revokeKeyUI('${k.name}')"` with a `data-revoke` attribute + `addEventListener` (a name can no longer break out of an event-handler string). The attacker-pickable `model` field (chosen in the request body, logged) is now escaped — the load-bearing sink.
- **server.mjs** — `POST /api/keys` rejects names not matching `/^[A-Za-z0-9 ._-]{1,64}$/` before `createKey()` (defense-in-depth; a `<script>`/quote name can never reach the DB). Creation-only; existing keys unaffected.

## ALIGNMENT.md
- **cli.js citation: N/A** — proxy-policy input validation, no Anthropic operation forwarded (Rule 2).
- No blacklisted tokens / port literals; `alignment.yml` passes.
- **Independent reviewer (Iron Rule 10):** fresh-context opus reviewer verified `escapeHtml` correctness (all 5 entities + null), **full sink coverage** (grepped all innerHTML sinks; confirmed the `data-revoke` attribute escapes a `"`-containing name and the attacker-pickable `model` field is escaped), revoke round-trips via `getAttribute`→`encodeURIComponent`, the anchored/length-bounded key-name regex runs before `createKey`, and `createKey` has no other unvalidated caller. `npm test` → **172 passed, 0 failed**. Verdict **APPROVE WITH MINOR** (both non-blocking).

## Noted (out of scope, optional follow-up)
The status/plan summary cards (`dashboard.html` `status-cards`/`plan-cards`) render trusted server/Anthropic-upstream values unescaped. Non-user-controlled, so not part of this stored-XSS fix — flagged for a possible uniform defense-in-depth pass later.

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
