### PR TITLE
chore(governance): pin legacy OAuth host in alignment.yml + ALIGNMENT.md amendment (#123)

### DIFF
--- a/.github/workflows/alignment.yml
+++ b/.github/workflows/alignment.yml
@@ -29,10 +29,14 @@ jobs:
             exit 0
           fi
 
-          # Known-hallucinated tokens. Extend only via an ALIGNMENT.md amendment PR.
-          # Each token is matched as a fixed string against server.mjs only.
+          # Blacklisted tokens — two kinds (see ALIGNMENT.md "OAuth token-host verification"):
+          #   (1) known LLM hallucinations (e.g. the 2026-04-11 /api/oauth/usage drift), and
+          #   (2) pinned wrong-host variants of a VERIFIED Class A endpoint (a hit means a
+          #       drift to a known-wrong host, not necessarily a hallucination).
+          # Extend only via an ALIGNMENT.md amendment PR. Matched as fixed strings vs server.mjs.
           BLACKLIST=(
             "api.anthropic.com/api/oauth/usage"
+            "console.anthropic.com/v1/oauth/token"
           )
 
           FAIL=0
@@ -51,8 +55,8 @@ jobs:
           ============================================================
           server.mjs contains a token on the OCP alignment blacklist.
 
-          These tokens were introduced by LLM hallucinations and do
-          not appear in cli.js at any shipped Claude Code version.
+          These tokens are either LLM hallucinations that never appeared in cli.js,
+          or pinned wrong-host variants of a verified Class A endpoint (a drift).
           See ALIGNMENT.md -> "Historical Lesson: The 2026-04-11 Drift"
           (commit b87992f) for the full incident record.
 

--- a/ALIGNMENT.md
+++ b/ALIGNMENT.md
@@ -52,6 +52,26 @@ The following Rules apply to **Class A operations** (the `cli.js`-mirror surface
 
 The audit pin is updated once per year (see Annual Alignment Audit) and whenever a drift incident forces a re-verification.
 
+### OAuth token-host verification (2026-05-31)
+
+Motivating evidence: the 2026-05-31 code audit (issues #112 / #119 / #123). The OAuth bearer
+machinery is a Class A surface (Rules 1–5). Because `cli.js` now ships as a
+compiled binary, the token-refresh host was re-verified against `claude.exe` (Claude Code
+`2.1.154`) on 2026-05-31 using the compiled-binary protocol — `strings` on the Mach-O, **no
+live OAuth probe** (a `refresh_token` grant would rotate the operator's real credentials):
+
+- **Verified host:** `https://platform.claude.com/v1/oauth/token` — present in the binary
+  byte-for-byte, paired with `OAUTH_CLIENT_ID` in the same `prod` config object (matches
+  `server.mjs` `OAUTH_TOKEN_URL` / `OAUTH_CLIENT_ID`). The legacy `console.anthropic.com/v1/oauth`
+  host is absent (0 hits).
+- **Pinned wrong-host variant:** `console.anthropic.com/v1/oauth/token` is added to the
+  `alignment.yml` blacklist so a future accidental revert to the legacy host hard-fails CI.
+
+The blacklist therefore now holds two kinds of token: (1) known hallucinations (e.g.
+`api.anthropic.com/api/oauth/usage`, the 2026-04-11 drift), and (2) pinned wrong-host variants
+of a *verified* Class A endpoint. A blacklist hit means either a re-introduced hallucination
+**or** a drift to a known-wrong host — both are alignment failures under Rules 2 and 3.
+
 ---
 
 ## Historical Lesson: The 2026-04-11 Drift


### PR DESCRIPTION
Follow-up to the 2026-05-31 audit (deferred from #112). The OAuth token host `platform.claude.com/v1/oauth/token` was verified against the compiled cli.js in #119; this **pins the legacy WRONG host** so a future accidental revert hard-fails CI.

- **alignment.yml**: add `console.anthropic.com/v1/oauth/token` to the BLACKLIST; rewrite the comment + failure message — the blacklist now documents TWO kinds of token (known hallucinations AND pinned wrong-host variants of a verified Class A endpoint). The pinned token is absent from server.mjs (which uses `platform.claude.com`), so CI stays green.
- **ALIGNMENT.md**: new "OAuth token-host verification (2026-05-31)" subsection recording the binary verification (claude.exe 2.1.154, `strings`, no live probe) + the dual-purpose blacklist policy. Purely additive.

Per ALIGNMENT.md **Amendment Procedure**: (a) motivating evidence cited (#112/#119/#123), (b) independent fresh-context opus reviewer **APPROVE** — verified the pinned token does not trip the build, YAML valid, amendment consistent with the server.mjs verification comment, purely additive scope; (c) not incident-driven, Historical Lesson unchanged.

Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)