### PR TITLE
chore(release): v3.21.1 — concurrency queue + spawn-token + TUI session-scope fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v3.21.1 — 2026-07-07
+
+Patch release: three bug fixes from an independent concurrency/session-lifecycle audit, each its own PR with a fresh-context reviewer (Iron Rule 10). No new `cli.js` wire behavior, no new endpoint, header, or env var; the `/health` field set is unchanged (only value truthfulness improved).
+
+### Fixed
+
+- **TUI session-scope / boot-reap (#148)** — `lib/tui/session.mjs`'s tmux session prefix is now scoped per-instance by listen port (`ocp-tui-<port>-`) instead of a bare host-wide `ocp-tui-` constant, so a second OCP instance on the same host (e.g. a temporary verification instance) can no longer have its live TUI sessions reaped or `kill-server`'d by another instance's boot/periodic sweep. The one-time boot reap also claims exact-shape legacy `ocp-tui-<8hex>` sessions (pre-fix naming) once, to clean up zombies left behind across an in-place upgrade.
+- **`-p` spawn-token mutex + keychain caching (#150)** — the real-HOME token fallback used when the keychain token is within its 5-minute expiry window is now serialized behind a mutex, so concurrent `-p` spawns no longer race the same single-use refresh token against each other (the credential-fork hazard). Added a 30s TTL cache + last-good-label memoization for the keychain read, cutting per-spawn event-loop blocking. The isolation decision (`/health` isolated/real-home reporting) is now re-evaluated per spawn instead of memoized forever, so `/health` no longer misreports a stale decision. New module `lib/spawn-auth.mjs` extracts the pure, unit-testable primitives (mutex, TTL cache, expiry gate, label ordering).
+- **Concurrency queue / disconnect handling (#149)** — the shared semaphore now honors a runtime-lowered `maxConcurrent` immediately (previously a decrease was silently ignored until in-flight tasks finished on their own) and wakes queued waiters right away when the limit is raised. Queued `-p`/TUI requests are now linked to the client's HTTP connection via `AbortSignal`; a client that disconnects while queued is spliced out of the queue instead of still spawning `claude` once a slot frees. A singleflight follower whose leader disconnected now retries instead of inheriting a spurious 500, and a queued-then-disconnected request is no longer recorded as a usage failure or logged as an error (quiet disconnect handling).
+
 ## v3.21.0 — 2026-06-25
 
 Cleanup + docs release: TUI dead-code removal, docs honesty, and release prep. No new `cli.js` wire behavior; the default path (`CLAUDE_TUI_MODE` unset) is byte-for-byte unchanged.

--- a/README.md
+++ b/README.md
@@ -894,6 +894,10 @@ node ~/ocp/scripts/sync-openclaw.mjs
 
 This is read-only at startup; the warning never blocks the gateway from running.
 
+### A TUI session vanished right after upgrading OCP
+
+If you ran a pre-3.21.1 OCP instance and a post-3.21.1 instance on the same host at the same time during an upgrade, the new instance's one-time boot reap can, once, kill an old-format (`ocp-tui-<8hex>`) live TUI session belonging to the still-running old instance — restart the affected session (`ocp restart` or re-run your TUI turn) and it will come back under the new instance's port-scoped naming.
+
 ### OpenClaw shows old models after `ocp update` (v3.10→v3.11 only)
 
 One-time bootstrap quirk for the v3.10.0 → v3.11.0 jump only — the running shell had the old `cmd_update` cached. Run once manually:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Patch release (3.21.0 → 3.21.1) bundling three already-merged bug-fix PRs. Bug fixes only, no new `cli.js` wire behavior, no new endpoint/header/env var.

- **#148** `fix(tui): session prefix + reap/kill-server scoped per-instance by port` — F7 audit finding; boot-reap also clears exact-format legacy `ocp-tui-<8hex>` sessions once.
- **#150** `fix(server): serialize -p real-HOME token fallback behind a mutex` — prevents concurrent refresh race on the single-use refresh token; 30s TTL keychain read cache + last-good-label memoization; de-staled isolation decision + truthful `/health` values (field set unchanged); new module `lib/spawn-auth.mjs` (pure testable primitives).
- **#149** `fix: semaphore honors runtime-lowered maxConcurrent` — setLimit wake/withhold; queued requests cancelled on client disconnect (AbortSignal plumbing; disconnected clients never spawn claude); singleflight follower retry on leader disconnect; exact queued accounting; quiet disconnect handling.

## Release-kit walk (CLAUDE.md Iron Rule 5.5)

| Item | Status |
|---|---|
| `package.json` version → 3.21.1 | **Touched** — `npm pkg set version=3.21.1` |
| `CHANGELOG.md` new v3.21.1 section | **Touched** — one entry per PR, matching existing format (see diff) |
| README § "All Commands" (new CLI subcommand) | **N/A** — no new CLI subcommand shipped (verified: diffed all 3 merged commits `2922d68..d96da46`, no new `ocp`/`ocp-connect` subcommand) |
| README § "Environment Variables" table | **N/A** — no new env var shipped (grepped all 3 diffs for `process.env.` additions; only pre-existing `process.env.HOME` referenced) |
| README § "API Endpoints" table | **N/A** — no new endpoint shipped (all 3 PRs are internal concurrency/session/auth-caching infra; each PR body explicitly declares "no endpoint, header, or request/response field added or changed") |
| README § "Available Models" table | **N/A** — none of the 3 PRs touch `models.json` |
| New auto-sync/hook doc | **N/A** — no new auto-sync or hook shipped |
| Architecture/contributor § for new file `lib/spawn-auth.mjs` | **N/A with caveat** — README's "Repository Layout" table only lists top-level files/dirs (`server.mjs`, `keys.mjs`, `scripts/sync-openclaw.mjs`, etc.); it does not already enumerate individual `lib/*.mjs` modules (no entry exists for `lib/tui/session.mjs`, `lib/tui/semaphore.mjs`, `lib/net.mjs`, etc. either), so there is no existing granular list to extend at that scope. `lib/spawn-auth.mjs` is documented in the CHANGELOG entry instead. |
| `bootstrap_quirk_policy`: one-time migration quirk → Troubleshooting | **Touched** — added one-sentence Troubleshooting note: running a pre-3.21.1 and post-3.21.1 OCP instance simultaneously on one host during upgrade can reap the old instance's live TUI session once at the new instance's boot (the one genuinely operator-visible caveat from #148; the general legacy-session boot-reap itself is automatic and not called out separately). |

## Test plan

- [x] `node --check server.mjs` — clean
- [x] `npm test` — **263 passed, 0 failed** at branch head (`da204ba`)
- [x] Diffed `2922d68..d96da46` (all 3 merged PR commits) to confirm no endpoint/env-var/CLI-command additions before writing the doc-walk table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)